### PR TITLE
Annotated form should always have 'no-text-transform' as style

### DIFF
--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -37,6 +37,7 @@ DEFAULT_LANGUAGE_VALUE = "default"
 LABEL = "label"
 HINT = "hint"
 STYLE = "style"
+STYLE_NO_TEXT_TRANSFORM = "no-text-transform"
 ATTRIBUTE = "attribute"
 ALLOW_CHOICE_DUPLICATES = "allow_choice_duplicates"
 

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -243,9 +243,24 @@ class Survey(Section):
             # try to resolve reference and fail if can't
             self.insert_xpaths(triggering_reference, self)
 
+        is_annotated_form = len(self.annotated_fields) > 0
         body_kwargs = {}
         if hasattr(self, constants.STYLE) and getattr(self, constants.STYLE):
             body_kwargs["class"] = getattr(self, constants.STYLE)
+
+            # Append 'no-text-transform' style into existing style for annotated form
+            if (
+                is_annotated_form
+                and constants.STYLE_NO_TEXT_TRANSFORM not in body_kwargs["class"]
+            ):
+                if len(body_kwargs["class"]) > 0:
+                    body_kwargs["class"] += " "
+                body_kwargs["class"] += constants.STYLE_NO_TEXT_TRANSFORM
+        else:
+            if is_annotated_form:
+                # Assign 'no-text-transform' style into existing style for annotated form
+                body_kwargs["class"] = constants.STYLE_NO_TEXT_TRANSFORM
+
         nsmap = self.get_nsmap()
 
         return node(

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -194,3 +194,57 @@ class AnnotateLabelTest(PyxformTestCase):
             xml__contains=[r"<label>This is info: $[check1] / $[check2]"],
             annotate=["all"],
         )
+
+    def test_annotated_label__body_class(self):
+        """
+        Test annotated label.
+        Form body class always contains text-no-transform.
+        """
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |
+            |        | type   |   name   | label |
+            |        | string |   name   | Name  |
+            """,
+            xml__contains=['<h:body class="no-text-transform">'],
+            annotate=["all"],
+        )
+
+    def test_annotated_label__body_class_existing_style(self):
+        """
+        Test annotated label with existing style.
+        Form body class always contains text-no-transform.
+        """
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |        |          |       |
+            |          | type   |   name   | label |
+            |          | string |   name   | Name  |
+            | settings |        |          |       |
+            |          | style      |      |       |
+            |          | theme-grid |      |       |
+            """,
+            xml__contains=['<h:body class="theme-grid no-text-transform">'],
+            annotate=["all"],
+        )
+
+    def test_annotated_label__body_class_existing_style_no_text_transform(self):
+        """
+        Test annotated label with no-text-transform in existing style.
+        Form body class always contains text-no-transform.
+        """
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |        |          |       |
+            |          | type   |   name   | label |
+            |          | string |   name   | Name  |
+            | settings |        |          |       |
+            |          | style                     |     |       |
+            |          | pages no-text-transform   |     |       |
+            """,
+            xml__contains=['<h:body class="pages no-text-transform">'],
+            annotate=["all"],
+        )


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
Simple but robust enough solution.
#### What are the regression risks?
No.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments