### PR TITLE
Annotate 'required' field

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -403,7 +403,7 @@ class SurveyElement(dict):
                 attr_value.split(underscore_str)
             )
 
-            if field_name == "relevant":
+            if field_name in ["relevant", "required"]:
                 # Replace > with gt
                 attr_value = attr_value.replace(">", "gt")
 
@@ -434,6 +434,7 @@ class SurveyElement(dict):
             annotated_value_styles = {
                 "itemgroup": "color: blue",
                 "relevant": "color: green",
+                "required": "color: red",
             }
             annotated_label_node = node(html_span)
             annotated_label = self.label
@@ -452,7 +453,11 @@ class SurveyElement(dict):
                 )
                 # Non-Choice fields
                 for idx, val in enumerate(survey.annotated_fields):
-                    if not hasattr(self, val) and val not in ["itemgroup", "relevant"]:
+                    if not hasattr(self, val) and val not in [
+                        "itemgroup",
+                        "relevant",
+                        "required",
+                    ]:
                         continue
 
                     attr_label = val.capitalize()
@@ -481,6 +486,8 @@ class SurveyElement(dict):
                         attr_value = self.get("bind", {}).get("relevant", "")
                         if attr_value != "":
                             attr_label = constants.ANNOTATE_RELEVANT
+                    elif val == "required":
+                        attr_value = self.get("bind", {}).get("required", "")
 
                     # Annotated value style
                     if val in annotated_value_styles.keys():

--- a/pyxform/xls2xform.py
+++ b/pyxform/xls2xform.py
@@ -110,7 +110,7 @@ def _create_parser():
     parser.add_argument(
         "--annotate",
         action="append",
-        choices=["name", "type", "itemgroup", "relevant", "all"],
+        choices=["name", "type", "itemgroup", "relevant", "required", "all"],
         help="Print XML forms with annotated label(s). This argument can be used multiple times.",
     )
     return parser

--- a/tests/pyxform_test_case.py
+++ b/tests/pyxform_test_case.py
@@ -100,7 +100,13 @@ class PyxformMarkdown:
         survey.title = kwargs.get("title")
         survey.id_string = kwargs.get("id_string")
 
-        default_annotate_fields_order = ["name", "type", "itemgroup", "relevant"]
+        default_annotate_fields_order = [
+            "name",
+            "type",
+            "itemgroup",
+            "relevant",
+            "required",
+        ]
         # Set annotated_fields from annotate parameter
         annotate = kwargs.get("annotate", [])
 

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -388,3 +388,37 @@ class AnnotateLabelTest(PyxformTestCase):
             ],
             annotate=["all"],
         )
+
+    def test_annotated_label__required(self):
+        """Test annotated label for item with required check."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |            |                                       |             |               |
+            |        | type      | name       | label                                 | calculation | required      |
+            |        | string    | field_name | Event_1                               |             |               |
+            |        | calculate | check1     |                                       | 1+1         |               |
+            |        | calculate | check2     |                                       | 2+1         |               |
+            |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} > 1 | 
+            """,
+            xml__contains=["[Required: $[check2] gt 1]"],
+            annotate=["all"],
+        )
+
+    def test_annotated_label__required_style(self):
+        """Test annotated label style for item with required check."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |            |                                       |             |               |
+            |        | type      | name       | label                                 | calculation | required      |
+            |        | string    | field_name | Event_1                               |             |               |
+            |        | calculate | check1     |                                       | 1+1         |               |
+            |        | calculate | check2     |                                       | 2+1         |               |
+            |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} > 1 | 
+            """,
+            xml__contains=[
+                '<h:span style="color: red">[Required: $[check2] gt 1] </h:span>'
+            ],
+            annotate=["all"],
+        )


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
Similar solution as PR #8 annotates relevant field.

#### What are the regression risks?
No.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments