### PR TITLE
Annotate CRF 'default' field

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -436,6 +436,7 @@ class SurveyElement(dict):
                 "relevant": "color: green",
                 "required": "color: red",
                 "constraint": "color: magenta",
+                "default": "color: deepskyblue",
             }
             annotated_label_node = node(html_span)
             annotated_label = self.label

--- a/pyxform/xls2xform.py
+++ b/pyxform/xls2xform.py
@@ -117,6 +117,7 @@ def _create_parser():
             "relevant",
             "required",
             "constraint",
+            "default",
             "all",
         ],
         help="Print XML forms with annotated label(s). This argument can be used multiple times.",

--- a/tests/pyxform_test_case.py
+++ b/tests/pyxform_test_case.py
@@ -107,6 +107,7 @@ class PyxformMarkdown:
             "relevant",
             "required",
             "constraint",
+            "default",
         ]
         # Set annotated_fields from annotate parameter
         annotate = kwargs.get("annotate", [])

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -429,7 +429,7 @@ class AnnotateLabelTest(PyxformTestCase):
             name="data",
             md="""
             | survey |           |            |                                       |             |               |
-            |        | type      | name       | label                                 | calculation | constraint      |
+            |        | type      | name       | label                                 | calculation | constraint    |
             |        | string    | field_name | Event_1                               |             |               |
             |        | calculate | check1     |                                       | 1+1         |               |
             |        | calculate | check2     |                                       | 2+1         |               |
@@ -445,7 +445,7 @@ class AnnotateLabelTest(PyxformTestCase):
             name="data",
             md="""
             | survey |           |            |                                       |             |               |
-            |        | type      | name       | label                                 | calculation | constraint      |
+            |        | type      | name       | label                                 | calculation | constraint    |
             |        | string    | field_name | Event_1                               |             |               |
             |        | calculate | check1     |                                       | 1+1         |               |
             |        | calculate | check2     |                                       | 2+1         |               |
@@ -453,6 +453,40 @@ class AnnotateLabelTest(PyxformTestCase):
             """,
             xml__contains=[
                 '&lt;span style="color: magenta"&gt; [Constraint: $[check2] gt 1]&lt;/span&gt;'
+            ],
+            annotate=["all"],
+        )
+
+    def test_annotated_label__default(self):
+        """Test annotated label for item with default check."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |            |                                       |             |               |
+            |        | type      | name       | label                                 | calculation | default       |
+            |        | string    | field_name | Event_1                               |             | default_name  |
+            |        | calculate | check1     |                                       | 1+1         |               |
+            |        | calculate | check2     |                                       | 2+1         |               |
+            |        | note      | info       | This is info:  ${check1} / ${check2}  |             |               |
+            """,
+            xml__contains=["[Default: default\_name]"],
+            annotate=["all"],
+        )
+
+    def test_annotated_label__default_style(self):
+        """Test annotated label style for item with default check."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |            |                                       |             |               |
+            |        | type      | name       | label                                 | calculation | default       |
+            |        | string    | field_name | Event_1                               |             | default_name  |
+            |        | calculate | check1     |                                       | 1+1         |               |
+            |        | calculate | check2     |                                       | 2+1         |               |
+            |        | note      | info       | This is info:  ${check1} / ${check2}  |             |               |
+            """,
+            xml__contains=[
+                '&lt;span style="color: deepskyblue"&gt; [Default: default\_name]&lt;/span&gt;'
             ],
             annotate=["all"],
         )


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
Follow previous PRs working solution.
#### What are the regression risks?
No.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments