### PR TITLE
Remove bind from annotated form item with relevant check in it.

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -587,6 +587,14 @@ class SurveyElement(dict):
             if self.trigger and "calculate" in self.bind:
                 del bind_dict["calculate"]
 
+            # Do not include "relevant" binding in annotated form
+            if (
+                len(survey.annotated_fields) > 0
+                and "relevant" in survey.annotated_fields
+                and "relevant" in self.bind
+            ):
+                return None
+
             for k, v in bind_dict.items():
                 # I think all the binding conversions should be happening on
                 # the xls2json side.

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -389,6 +389,24 @@ class AnnotateLabelTest(PyxformTestCase):
             annotate=["all"],
         )
 
+    def test_annotated_label__relevant_bind(self):
+        """Test annotated label bind for item with relevant check."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |            |                                       |             |               |
+            |        | type      | name       | label                                 | calculation | relevant      |
+            |        | string    | field_name | Event_1                               |             |               |
+            |        | calculate | check1     |                                       | 1+1         |               |
+            |        | calculate | check2     |                                       | 2+1         |               |
+            |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} > 1 |
+            """,
+            xml__not_contains=[
+                '<bind nodeset="/data/info" readonly="true()" relevant=" /data/check2  &gt; 1" type="string"/>'
+            ],
+            annotate=["all"],
+        )
+
     def test_annotated_label__required(self):
         """Test annotated label for item with required check."""
         self.assertPyxformXform(


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
Simple and no nonsense solution.
#### What are the regression risks?
No. Passed all tests.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments