### PR TITLE
Annotate CRF 'default' field: Fixed string replacement for '<' and '>'

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -403,7 +403,7 @@ class SurveyElement(dict):
                 attr_value.split(underscore_str)
             )
 
-            if field_name in ["relevant", "required", "constraint"]:
+            if field_name in ["relevant", "required", "constraint", "default"]:
                 # Replace > with gt
                 attr_value = attr_value.replace(">", "gt")
 


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
Continue works started in PR #12 
#### What are the regression risks?
None.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments