### PR TITLE
Annotate CRF 'type' and 'name' field style

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -476,7 +476,7 @@ class SurveyElement(dict):
                     ]:
                         continue
 
-                    attr_label = val.capitalize()
+                    attr_label = val.title()
                     attr_value = ""
                     attr_style = ""
                     if hasattr(self, val):

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -451,7 +451,6 @@ class SurveyElement(dict):
                 "trigger": "color: darkgreen",
                 "readonly": "color: chocolate",
             }
-            annotated_label_node = node(html_span)
             annotated_label = self.label
             # Choices
             if is_choices and hasattr(self, "label") and hasattr(self, "name"):
@@ -461,7 +460,6 @@ class SurveyElement(dict):
                 annotated_label = self.annotated_value_processing(
                     annotated_label, "choices"
                 )
-                annotated_label_node.appendChild(node(html_span, annotated_label))
             else:
                 annotated_label = self.annotated_value_processing(
                     annotated_label, "not choices"

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -442,6 +442,8 @@ class SurveyElement(dict):
             html_span = "h:span"
             html_br = "h:br"
             annotated_value_styles = {
+                "type": "color: black",
+                "name": "color: orangered",
                 "itemgroup": "color: blue",
                 "relevant": "color: green",
                 "required": "color: red",

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -17,7 +17,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | type   |   name   | label |
             |        | string |   name   | Name  |
             """,
-            xml__contains=["[Name: name] [Type: string]"],
+            xml__contains=["[Name: name]", "[Type: string]"],
             annotate=["type", "name"],
         )
 
@@ -30,7 +30,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | type   |   name   | label |
             |        | string |   name   | Name  |
             """,
-            xml__not_contains=["[Name: name] [Type: string]"],
+            xml__not_contains=["[Name: name]", "[Type: string]"],
         )
 
     def test_annotated_label_contains_newline(self):
@@ -42,7 +42,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | type   |   name   | label |
             |        | string |   name   | Name  |
             """,
-            xml__contains=["<label>Name\n"],
+            xml__contains=["\n"],
             annotate=["type"],
         )
 
@@ -55,7 +55,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | type   | name       | label |
             |        | string | field_name | Name  |
             """,
-            xml__contains=[r"[Name: field\_name] [Type: string]</label>"],
+            xml__contains=[r"[Name: field\_name]"],
             annotate=["type", "name"],
         )
 
@@ -84,7 +84,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |          | choices1            | 1    | One   |
             |          | choices1            | 2    | Two   |
             """,
-            xml__contains=[r"[Name: a] [Type: select\_one choices1]</label>"],
+            xml__contains=[r"[Type: select\_one choices1]"],
             annotate=["type", "name"],
         )
 
@@ -100,7 +100,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |          | choices1                 | 1    | One   |
             |          | choices1                 | 2    | Two   |
             """,
-            xml__contains=[r"[Name: a] [Type: select\_multiple choices1]</label>"],
+            xml__contains=[r"[Type: select\_multiple choices1]"],
             annotate=["type", "name"],
         )
 
@@ -164,7 +164,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | type   |   name   | label |
             |        | string |   name   | Name  |
             """,
-            xml__contains=["[Name: name] [Type: string]</label>"],
+            xml__contains=["[Name: name]", "[Type: string]"],
             annotate=["all"],
         )
 
@@ -177,7 +177,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | type   |   name   | label |
             |        | string |   name   | Name  |
             """,
-            xml__contains=["[Name: name] [Type: string]</label>"],
+            xml__contains=["[Name: name]", "[Type: string]"],
             annotate=["type", "all"],
         )
 
@@ -324,6 +324,36 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | end repeat   |         |          |
             """,
             xml__contains=['<repeat nodeset="/data/repeat1">'],
+            annotate=["all"],
+        )
+
+    def test_annotated_label__type_style(self):
+        """Test annotated label style for item type."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |         |        |        |
+            |        | type    | name   | label  |
+            |        | string  | title  | Title: |
+            """,
+            xml__contains=[
+                '&lt;span style="color: black"&gt; [Type: string]&lt;/span&gt;'
+            ],
+            annotate=["all"],
+        )
+
+    def test_annotated_label__name_style(self):
+        """Test annotated label style for item name."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |         |        |        |
+            |        | type    | name   | label  |
+            |        | string  | title  | Title: |
+            """,
+            xml__contains=[
+                '&lt;span style="color: orangered"&gt; [Name: title]&lt;/span&gt;'
+            ],
             annotate=["all"],
         )
 
@@ -551,7 +581,7 @@ class AnnotateLabelTest(PyxformTestCase):
             | survey |           |           |                   |              |
             |        | type      | name      | label             | trigger      |
             |        | integer   | resprate  | Respiratory Rate: |              |
-            |        | integer   | pulse     | Pulse:            | ${resprate} |
+            |        | integer   | pulse     | Pulse:            | ${resprate}  |
             """,
             xml__contains=["[Trigger: $[resprate]]"],
             annotate=["all"],
@@ -565,7 +595,7 @@ class AnnotateLabelTest(PyxformTestCase):
             | survey |           |           |                   |              |
             |        | type      | name      | label             | trigger      |
             |        | integer   | resprate  | Respiratory Rate: |              |
-            |        | integer   | pulse     | Pulse:            | ${resprate} |
+            |        | integer   | pulse     | Pulse:            | ${resprate}  |
             """,
             xml__contains=[
                 '&lt;span style="color: darkgreen"&gt; [Trigger: $[resprate]]&lt;/span&gt;'


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
Continue working solution of previous PRs.
#### What are the regression risks?
None.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments