### PR TITLE
Do not show default value in annotated field

### DIFF
--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -34,7 +34,14 @@ class Question(SurveyElement):
         for key, value in attributes.items():
             attributes[key] = survey.insert_xpaths(value, self)
 
-        if self.get("default") and not default_is_dynamic(self.default, self.type):
+        if (
+            self.get("default")
+            and not default_is_dynamic(self.default, self.type)
+            and (
+                len(survey.annotated_fields) == 0
+                or "default" not in survey.annotated_fields
+            )
+        ):
             return node(self.name, str(self.get("default")), **attributes)
         return node(self.name, **attributes)
 

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -521,6 +521,38 @@ class AnnotateLabelTest(PyxformTestCase):
             annotate=["all"],
         )
 
+    def test_annotated_label__default__instance_without_default_value_1(self):
+        """Test instance of field with default name should not contains its default value"""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |            |                                       |             |               |
+            |        | type      | name       | label                                 | calculation | default       |
+            |        | string    | field_name | Event_1                               |             | default_name  |
+            |        | calculate | check1     |                                       | 1+1         |               |
+            |        | calculate | check2     |                                       | 2+1         |               |
+            |        | note      | info       | This is info:  ${check1} / ${check2}  |             |               |
+            """,
+            xml__not_contains=["<field_name>default_name</field_name>"],
+            annotate=["all"],
+        )
+
+    def test_annotated_label__default__instance_without_default_value_2(self):
+        """Test instance of field with default name should not contains its default value"""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |            |                                       |             |               |
+            |        | type      | name       | label                                 | calculation | default       |
+            |        | string    | field_name | Event_1                               |             | default_name  |
+            |        | calculate | check1     |                                       | 1+1         |               |
+            |        | calculate | check2     |                                       | 2+1         |               |
+            |        | note      | info       | This is info:  ${check1} / ${check2}  |             |               |
+            """,
+            xml__contains=["<field_name/>"],
+            annotate=["all"],
+        )
+
     def test_annotated_label__default_style(self):
         """Test annotated label style for item with default check."""
         self.assertPyxformXform(


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
The simplest yet working solution.
#### What are the regression risks?
No.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments