### PR TITLE
Annotated CRF support for item type "image", "audio", and "video"

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -508,6 +508,8 @@ class SurveyElement(dict):
                                 and getattr(self, "itemset") != ""
                             ):
                                 attr_value += "_from_file " + getattr(self, "itemset")
+                        elif attr_value == "photo":
+                            attr_value = "image"
                     elif val == "itemgroup":
                         attr_value = self.get("bind", {}).get("oc:itemgroup", "")
                         if attr_value != "":

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -120,11 +120,50 @@ class AnnotateLabelTest(PyxformTestCase):
         """Test annotated label for select multiple from file."""
         self.assertPyxformXform(
             md="""
-            | survey   |                               |                                  |                           |
-            |          | type                          | name                             | label                     |
+            | survey   |                                    |                             |                           |
+            |          | type                               | name                        | label                     |
             |          | select_multiple_from_file file.csv | select_multiple_from_file_1 | Select multiple from file |
             """,
             xml__contains=[r"[Type: select\_multiple\_from\_file file.csv]"],
+            annotate=["all"],
+        )
+
+    def test_annotated_label__for_image(self):
+        """Test annotated label for image."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |       |            |       |
+            |        | type  | name       | label |
+            |        | image | image_name | Image |
+            """,
+            xml__contains=[r"[Name: image\_name]", "[Type: image]"],
+            annotate=["all"],
+        )
+
+    def test_annotated_label__for_audio(self):
+        """Test annotated label for audio."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |       |            |       |
+            |        | type  | name       | label |
+            |        | audio | audio_name | audio |
+            """,
+            xml__contains=[r"[Name: audio\_name]", "[Type: audio]"],
+            annotate=["all"],
+        )
+
+    def test_annotated_label__for_video(self):
+        """Test annotated label for video."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |       |            |       |
+            |        | type  | name       | label |
+            |        | video | video_name | video |
+            """,
+            xml__contains=[r"[Name: video\_name]", "[Type: video]"],
             annotate=["all"],
         )
 


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
It works.
#### What are the regression risks?
None.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments