### PR TITLE
Fixed handling of "<" char in annotated CRF label

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -419,7 +419,7 @@ class SurveyElement(dict):
                 attr_value = attr_value.replace(">", "gt")
 
                 # Replace < with lt
-                attr_value = attr_value.replace(">", "gt")
+                attr_value = attr_value.replace("<", "lt")
 
         # Replace { with [
         attr_value = attr_value.replace("{", "[")

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -521,10 +521,10 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | string    | field_name | Event_1                               |             |               |
             |        | calculate | check1     |                                       | 1+1         |               |
             |        | calculate | check2     |                                       | 2+1         |               |
-            |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} > 1 |
+            |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} < 1 |
             """,
             xml__contains=[
-                '&lt;span style="color: magenta"&gt; [Constraint: $[check2] gt 1]&lt;/span&gt;'
+                '&lt;span style="color: magenta"&gt; [Constraint: $[check2] lt 1]&lt;/span&gt;'
             ],
             annotate=["all"],
         )


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
Simple fix.
#### What are the regression risks?
None.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments