### PR TITLE
Annotate CRF support for multilanguage fields : relevant, required, constraint, calculation, readonly

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -433,18 +433,24 @@ class SurveyElement(dict):
 
         return attr_value
 
+    def get_field_or_lang_dict_value(self, field, lang=None):
+        if not isinstance(field, dict):
+            return field
+        else:
+            try:
+                if lang is not None:
+                    return field[lang]
+                else:
+                    return next(iter(field))
+            except KeyError:
+                return ""
+
     def get_annotated_label(self, lang=None):
         survey = self.get_root()
         is_annotated = len(self.get_root().annotated_fields) > 0
 
         if not is_annotated:
-            if not isinstance(self.label, dict):
-                return self.label
-            else:
-                if lang is not None:
-                    return self.label[lang]
-                else:
-                    return next(iter(self.label))
+            return self.get_field_or_lang_dict_value(self.label, lang)
         else:
             is_choices = self.parent.type in [
                 constants.SELECT_ONE,
@@ -465,21 +471,12 @@ class SurveyElement(dict):
                 "repeat_count": "color: lime",
                 "external": "color: indigo",
             }
-            if not isinstance(self.label, dict):
-                annotated_label = self.label
-            else:
-                if lang is not None:
-                    annotated_label = self.label[lang]
-                else:
-                    annotated_label = next(iter(self.label))
+            annotated_label = self.get_field_or_lang_dict_value(self.label, lang)
             # Choices
             if is_choices and hasattr(self, "label") and hasattr(self, "name"):
-                choice_label = getattr(self, "label")
-                if isinstance(choice_label, dict):
-                    if lang is not None:
-                        choice_label = choice_label[lang]
-                    else:
-                        choice_label = next(iter(choice_label))
+                choice_label = self.get_field_or_lang_dict_value(
+                    getattr(self, "label"), lang
+                )
                 annotated_label = "{} [{}]".format(choice_label, getattr(self, "name"))
                 annotated_label = self.annotated_value_processing(
                     annotated_label, "choices"
@@ -537,21 +534,31 @@ class SurveyElement(dict):
                         if attr_value != "":
                             attr_label = constants.ANNOTATE_ITEMGROUP
                     elif val == "relevant":
-                        attr_value = self.get("bind", {}).get("relevant", "")
+                        attr_value = self.get_field_or_lang_dict_value(
+                            self.get("bind", {}).get("relevant", ""), lang
+                        )
                         if attr_value != "":
                             attr_label = constants.ANNOTATE_RELEVANT
                     elif val == "required":
-                        attr_value = self.get("bind", {}).get("required", "")
+                        attr_value = self.get_field_or_lang_dict_value(
+                            self.get("bind", {}).get("required", ""), lang
+                        )
                     elif val == "constraint":
-                        attr_value = self.get("bind", {}).get("constraint", "")
+                        attr_value = self.get_field_or_lang_dict_value(
+                            self.get("bind", {}).get("constraint", ""), lang
+                        )
                     elif val == "calculation":
                         attr_value = self.get("bind", {}).get("calculate", "")
                     elif val == "readonly":
-                        attr_value = self.get("bind", {}).get("readonly", "")
+                        attr_value = self.get_field_or_lang_dict_value(
+                            self.get("bind", {}).get("readonly", ""), lang
+                        )
                         if attr_value != "":
                             attr_label = constants.ANNOTATE_READONLY
                     elif val == "image":
-                        attr_value = self.get("media", {}).get("image", "")
+                        attr_value = self.get_field_or_lang_dict_value(
+                            self.get("media", {}).get("image", ""), lang
+                        )
                     elif val == "repeat_count" and self.type == "repeat":
                         repeat_count_model = next(
                             filter(

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -677,6 +677,119 @@ class TestTranslationsSurvey(PyxformTestCase):
             warnings_count=0,
         )
 
+    def test_no_default__two_translation__annotated_label_with_image(self):
+        """Should find language translations for annotated label with translated image."""
+        md = """
+        | survey |      |      |                |                   |                |                   |
+        |        | type | name | label::english | label::indonesian | image::english | image::indonesian |
+        |        | note | n1   | note label     | catatan           | english.jpg    | indonesian.jpg    |
+        """
+        self.assertPyxformXform(
+            name="test",
+            md=md,
+            xml__xpath_match=[
+                self.xp.question_label_references_itext(),
+                self.xp.question_itext_like_label("english", "Image: english.jpg"),
+                self.xp.question_itext_like_label("indonesian", "Image: indonesian.jpg"),
+            ],
+            annotate=["all"],
+            warnings_count=0,
+        )
+
+    def test_no_default__two_translation__annotated_label_with_relevant_check(self):
+        """Should find language translations for annotated label with relevant check."""
+        md = """
+        | survey |                  |            |                |                   |                   |                      |
+        |        | type             | name       | label::english | label::indonesian | relevant::english | relevant::indonesian |
+        |        | select_one show  | select_1_s | show?          | sembunyikan?      |                   |                      |
+        |        | note             | n1         | note label     | catatan           | ${select_1_s} = 1 | ${select_1_s} = 2    |
+        | choices  |             |            |             |
+        |          | list_name   | name       | label       |
+        |          | show        | 1          | Yes         |
+        |          | show        | 2          | No          |
+        """
+        self.assertPyxformXform(
+            name="test",
+            md=md,
+            xml__xpath_match=[
+                self.xp.question_label_references_itext(),
+                self.xp.question_itext_like_label(
+                    "english", "Show When: $[select\_1\_s] = 1"
+                ),
+                self.xp.question_itext_like_label(
+                    "indonesian", "Show When: $[select\_1\_s] = 2"
+                ),
+            ],
+            annotate=["all"],
+            warnings_count=0,
+        )
+
+    def test_no_default__two_translation__annotated_label_with_required_check(self):
+        """Should find language translations for annotated label with required check."""
+        md = """
+        | survey |                  |            |                |                   |                   |                      |
+        |        | type             | name       | label::english | label::indonesian | required::english | required::indonesian |
+        |        | note             | n1         | note label     | catatan           | true              | false                |
+        """
+        self.assertPyxformXform(
+            name="test",
+            md=md,
+            xml__xpath_match=[
+                self.xp.question_label_references_itext(),
+                self.xp.question_itext_like_label("english", "Required: true"),
+                self.xp.question_itext_like_label("indonesian", "Required: false"),
+            ],
+            annotate=["all"],
+            warnings_count=0,
+        )
+
+    def test_no_default__two_translation__annotated_label_with_constraint_check(self):
+        """Should find language translations for annotated label with constraint check."""
+        md = """
+        | survey |                  |            |                |                   |                     |                        |
+        |        | type             | name       | label::english | label::indonesian | constraint::english | constraint::indonesian |
+        |        | select_one show  | select_1_s | show?          | sembunyikan?      |                     |                        |
+        |        | note             | n1         | note label     | catatan           | ${select_1_s} = 1   | ${select_1_s} = 2      |
+        | choices  |             |            |             |
+        |          | list_name   | name       | label       |
+        |          | show        | 1          | Yes         |
+        |          | show        | 2          | No          |
+        """
+        self.assertPyxformXform(
+            name="test",
+            md=md,
+            xml__xpath_match=[
+                self.xp.question_label_references_itext(),
+                self.xp.question_itext_like_label(
+                    "english", "Constraint: $[select\_1\_s] = 1"
+                ),
+                self.xp.question_itext_like_label(
+                    "indonesian", "Constraint: $[select\_1\_s] = 2"
+                ),
+            ],
+            annotate=["all"],
+            warnings_count=0,
+        )
+
+    def test_no_default__two_translation__annotated_label_with_readonly_check(self):
+        """Should find language translations for annotated label with readonly check."""
+        md = """
+        | survey |                  |            |                |                   |                   |                      |
+        |        | type             | name       | label::english | label::indonesian | readonly::english | readonly::indonesian |
+        |        | note             | n1         | note label     | catatan           | yes               | no                   |
+        """
+        self.assertPyxformXform(
+            name="test",
+            md=md,
+            xml__xpath_match=[
+                self.xp.question_label_references_itext(),
+                self.xp.question_itext_like_label("english", "Read-Only: yes"),
+                self.xp.question_itext_like_label("indonesian", "Read-Only: no"),
+            ],
+            annotate=["all"],
+            warnings_count=0,
+        )
+
     def test_no_default__one_translation__label_and_hint_with_image(self):
         """Should find language translations for label, hint, and image."""
         md = """


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
Slightly similar solution with multilanguage label and name.
#### What are the regression risks?
None.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments