### PR TITLE
aCRF escape asterisks for some fields

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -425,6 +425,16 @@ class SurveyElement(dict):
                 # Replace < with lt
                 attr_value = attr_value.replace("<", "lt")
 
+            if field_name in [
+                "relevant",
+                "constraint",
+                "default",
+                "calculation",
+                "required",
+            ]:
+                # Prepend * with \
+                attr_value = attr_value.replace("*", "\*")
+
         # Replace { with [
         attr_value = attr_value.replace("{", "[")
 

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -502,14 +502,14 @@ class AnnotateLabelTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |           |            |                                       |             |               |
-            |        | type      | name       | label                                 | calculation | relevant      |
-            |        | string    | field_name | Event_1                               |             |               |
-            |        | calculate | check1     |                                       | 1+1         |               |
-            |        | calculate | check2     |                                       | 2+1         |               |
-            |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} > 1 |
+            | survey |           |            |                                       |             |                   |
+            |        | type      | name       | label                                 | calculation | relevant          |
+            |        | string    | field_name | Event_1                               |             |                   |
+            |        | calculate | check1     |                                       | 1+1         |                   |
+            |        | calculate | check2     |                                       | 2+1         |                   |
+            |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} > 1 * 2 |
             """,
-            xml__contains=["[Show When: $[check2] gt 1]"],
+            xml__contains=["[Show When: $[check2] gt 1 \* 2]"],
             annotate=["all"],
         )
 
@@ -554,14 +554,14 @@ class AnnotateLabelTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |           |            |                                       |             |               |
-            |        | type      | name       | label                                 | calculation | required      |
-            |        | string    | field_name | Event_1                               |             |               |
-            |        | calculate | check1     |                                       | 1+1         |               |
-            |        | calculate | check2     |                                       | 2+1         |               |
-            |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} > 1 |
+            | survey |           |            |                                       |             |                   |
+            |        | type      | name       | label                                 | calculation | required          |
+            |        | string    | field_name | Event_1                               |             |                   |
+            |        | calculate | check1     |                                       | 1+1         |                   |
+            |        | calculate | check2     |                                       | 2+1         |                   |
+            |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} > 1 * 3 |
             """,
-            xml__contains=["[Required: $[check2] gt 1]"],
+            xml__contains=["[Required: $[check2] gt 1 \* 3]"],
             annotate=["all"],
         )
 
@@ -588,14 +588,14 @@ class AnnotateLabelTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |           |            |                                       |             |               |
-            |        | type      | name       | label                                 | calculation | constraint    |
-            |        | string    | field_name | Event_1                               |             |               |
-            |        | calculate | check1     |                                       | 1+1         |               |
-            |        | calculate | check2     |                                       | 2+1         |               |
-            |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} > 1 |
+            | survey |           |            |                                       |             |                   |
+            |        | type      | name       | label                                 | calculation | constraint        |
+            |        | string    | field_name | Event_1                               |             |                   |
+            |        | calculate | check1     |                                       | 1+1         |                   |
+            |        | calculate | check2     |                                       | 2+1         |                   |
+            |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} > 1 * 4 |
             """,
-            xml__contains=["[Constraint: $[check2] gt 1]"],
+            xml__contains=["[Constraint: $[check2] gt 1 \* 4]"],
             annotate=["all"],
         )
 


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
Continue working solution.
#### What are the regression risks?
None.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments