### PR TITLE
aCRF shows calculate type in the end of form

### DIFF
--- a/pyxform/section.py
+++ b/pyxform/section.py
@@ -108,10 +108,21 @@ class Section(SurveyElement):
         Ideally, we'll have groups up and rolling soon, but for now
         let's just yield controls from all the children of this section
         """
-        for e in self.children:
-            control = e.xml_control()
-            if control is not None:
-                yield control
+        if len(self.get_root().annotated_fields) > 0:
+            calculate_children = filter(lambda c: c.type == "calculate", self.children)
+            non_calculate_children = filter(
+                lambda c: c.type != "calculate", self.children
+            )
+            for list in [non_calculate_children, calculate_children]:
+                for e in list:
+                    control = e.xml_control()
+                    if control is not None:
+                        yield control
+        else:
+            for e in self.children:
+                control = e.xml_control()
+                if control is not None:
+                    yield control
 
 
 class RepeatingSection(Section):

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -679,7 +679,11 @@ class SurveyElement(dict):
         """
         result = []
         label_appended = False
-        if self.label or self.media:
+        if (
+            self.label
+            or self.media
+            or (len(self.get_root().annotated_fields) > 0 and self.type == "calculate")
+        ):
             result.append(self.xml_label())
             label_appended = True
 

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -776,6 +776,24 @@ class AnnotateLabelTest(PyxformTestCase):
             annotate=["all"],
         )
 
+    def test_annotated_label__calculation_type(self):
+        """Test annotated label for calculation type item"""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |                |                |               |          |          |
+            |        | type      | name           | label          | calculation   | required | readonly |
+            |        | calculate | calculate_type |                | 2+3           |          |          |
+            |        | date      | dob            | Date of birth: |               | yes      |          |
+            |        | date      | date_visit     | Date of visit: |               | yes      |          |
+            """,
+            xml__contains=[
+                '<input ref="/data/calculate_type">',
+                'style="color: black"&gt; [Type: calculate]&lt;/span&gt;&lt;span style="color: maroon"&gt; [Calculation: 2+3]&lt;/span&gt;</label>',
+            ],
+            annotate=["all"],
+        )
+
     def test_annotated_label__trigger(self):
         """Test annotated label for item with trigger."""
         self.assertPyxformXform(


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
Simple yet works.
#### What are the regression risks?
None.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments