### PR TITLE
aCRF choices value when choice_filter is true

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -520,6 +520,13 @@ class Survey(Section):
 
         # Append last so the choice instance is excluded on a name clash.
         for name, value in self.choices.items():
+            if len(self.annotated_fields) > 0:
+                for choice in value:
+                    for choice_item_name, choice_item_value in choice.items():
+                        if choice_item_name == "label" and "name" in choice:
+                            choice[choice_item_name] = "{} [{}]".format(
+                                choice_item_value, choice.get("name")
+                            )
             instances += [
                 self._generate_static_instances(list_name=name, choice_list=value)
             ]
@@ -693,6 +700,11 @@ class Survey(Section):
                 for name, choice_value in choice.items():
                     itext_id = "-".join([list_name, str(idx)])
                     if isinstance(choice_value, dict):
+                        if len(self.annotated_fields) > 0 and "name" in choice:
+                            choice_value = {
+                                lang: "{} [{}]".format(value, choice.get("name"))
+                                for lang, value in choice_value.items()
+                            }
                         _setup_choice_translations(name, choice_value, itext_id)
                     elif name == "label":
                         self._add_to_nested_dict(

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -1076,6 +1076,40 @@ class AnnotateLabelTest(PyxformTestCase):
             annotate=["all"],
         )
 
+    def test_annotate_label__for_choices_with_choice_filter_true(self):
+        """Test annotated label for choice item with choice filter true."""
+        self.assertPyxformXform(
+            md="""
+            | survey   |                     |             |        |                |
+            |          | type                | name        | label  | choice_filter  |
+            |          | integer             | int_num     | Number |                |
+            |          | select_one choices1 | sel_choices | Select | true()         |
+            | choices  |                     |             |        |                |
+            |          | list_name           | name        | label  |                |
+            |          | choices1            | 1           | One    |                |
+            |          | choices1            | 2           | Two    |                |
+            """,
+            xml__contains=["<label>Two [2]</label>"],
+            annotate=["all"],
+        )
+
+    def test_annotate_label__for_multilanguage_choices_with_choice_filter_true(self):
+        """Test annotated label for multilanguage choice item with choice filter true."""
+        self.assertPyxformXform(
+            md="""
+            | survey   |                     |             |                      |                        |                |
+            |          | type                | name        | label::English (en)  | label::Indonesia (id)  | choice_filter  |
+            |          | integer             | int_num     | Number               | Nomor                  |                |
+            |          | select_one choices1 | sel_choices | Select               | Pilih                  | true()         |
+            | choices  |                     |             |                      |                        |                |
+            |          | list_name           | name        | label::English (en)  | label::Indonesia (id)  |                |
+            |          | choices1            | 1           | One                  | Satu                   |                |
+            |          | choices1            | 2           | Two                  | Dua                    |                |
+            """,
+            xml__contains=["<value>One [1]</value>"],
+            annotate=["all"],
+        )
+
     def test_annotated_label_identifier(self):
         """Test annotated label for item with identifier field."""
         self.assertPyxformXform(


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
Global yet fast solution.
#### What are the regression risks?
None.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments