### PR TITLE
Always shows choice filter regardless of choice_filter value

### DIFF
--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -261,6 +261,8 @@ class MultipleChoiceQuestion(Question):
             choice_filter = survey.insert_xpaths(
                 choice_filter, self, True, is_previous_question
             )
+            if choice_filter != "true()" and len(survey.annotated_fields) > 0:
+                choice_filter = "true()"
             if is_previous_question:
                 path = (
                     survey.insert_xpaths(self["itemset"], self, reference_parent=True)

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -1114,6 +1114,23 @@ class AnnotateLabelTest(PyxformTestCase):
             annotate=["all"],
         )
 
+    def test_annotate_label__for_choices_with_choice_filter_false(self):
+        """Test annotated label for choice item with choice filter true. Always shows choice item regardless of choice filter value"""
+        self.assertPyxformXform(
+            md="""
+            | survey   |                     |             |        |                |
+            |          | type                | name        | label  | choice_filter  |
+            |          | integer             | int_num     | Number |                |
+            |          | select_one choices1 | sel_choices | Select | false()        |
+            | choices  |                     |             |        |                |
+            |          | list_name           | name        | label  |                |
+            |          | choices1            | 1           | One    |                |
+            |          | choices1            | 2           | Two    |                |
+            """,
+            xml__contains=["<label>One [1]</label>"],
+            annotate=["all"],
+        )
+
     def test_annotate_label__for_multilanguage_choices_with_choice_filter_true(self):
         """Test annotated label for multilanguage choice item with choice filter true."""
         self.assertPyxformXform(
@@ -1128,6 +1145,23 @@ class AnnotateLabelTest(PyxformTestCase):
             |          | choices1            | 2           | Two                  | Dua                    |                |
             """,
             xml__contains=["<value>One [1]</value>"],
+            annotate=["all"],
+        )
+
+    def test_annotate_label__for_multilanguage_choices_with_choice_filter_false(self):
+        """Test annotated label for multilanguage choice item with choice filter true. Always shows choice item regardless of choice filter value"""
+        self.assertPyxformXform(
+            md="""
+            | survey   |                     |             |                      |                        |                |
+            |          | type                | name        | label::English (en)  | label::Indonesia (id)  | choice_filter  |
+            |          | integer             | int_num     | Number               | Nomor                  |                |
+            |          | select_one choices1 | sel_choices | Select               | Pilih                  | false()        |
+            | choices  |                     |             |                      |                        |                |
+            |          | list_name           | name        | label::English (en)  | label::Indonesia (id)  |                |
+            |          | choices1            | 1           | One                  | Satu                   |                |
+            |          | choices1            | 2           | Two                  | Dua                    |                |
+            """,
+            xml__contains=["<value>Two [2]</value>"],
             annotate=["all"],
         )
 


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?

#### What are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments