### PR TITLE
Fixed invalid version number and merge upstream v1.12.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
-on: [release]
+on:
+  release:
+    types: [published]
 
 jobs:
   release:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -30,8 +30,8 @@ jobs:
           pip list
 
       # Linters.
-      - run: black pyxform tests
-      - run: isort pyxform tests
+      - run: black pyxform tests --check --diff
+      - run: isort pyxform tests --check-only --diff
       - run: flake8 pyxform tests
       - run: pycodestyle pyxform tests
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,20 @@
 Pyxform Changelog
 
+v1.12.1, 2023-05-16
+* Pass through itemset ref case by @lognaturel in https://github.com/XLSForm/pyxform/pull/644
+
+v1.12.0, 2023-01-19
+* Add support for big-image by @lognaturel in https://github.com/XLSForm/pyxform/pull/635
+* Show error when there are `save_to`s in a repeat, simplify entities tests by @lognaturel in https://github.com/XLSForm/pyxform/pull/636
+* Ignore media column if it is present by @lognaturel in https://github.com/XLSForm/pyxform/pull/638
+
+# v1.11.1, 2022-11-18
+* Add __init__.py to `entities` package by @lognaturel in https://github.com/XLSForm/pyxform/pull/628
+
+# v1.11.0, 2022-11-18
+* Accept more empty rows before stopping by @yanokwa in https://github.com/XLSForm/pyxform/pull/621
+* Add initial support for entity creation by @lognaturel in https://github.com/XLSForm/pyxform/pull/624
+
 # v1.10.1, 2022-06-24
 * avoid processing vast empty areas of buggy / strange workbooks by @lindsay-stevens in https://github.com/XLSForm/pyxform/pull/612
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ===============
-pyxform vOC-1.0.2
+pyxform v1.0.3-oc
 ===============
 
 |python| |black|

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ===============
-pyxform v1.0.3-oc
+pyxform v1.0.3+oc
 ===============
 
 |python| |black|

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ===============
-pyxform v1.0.3+oc
+pyxform v1.0.3.oc
 ===============
 
 |python| |black|

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ===============
-pyxform v1.0.3.oc
+pyxform v1.0.3+oc
 ===============
 
 |python| |black|

--- a/pyxform/__init__.py
+++ b/pyxform/__init__.py
@@ -4,7 +4,7 @@ pyxform is a Python library designed to make authoring XForms for ODK
 Collect easy.
 """
 
-__version__ = "1.0.3.oc"
+__version__ = "1.0.3+oc"
 
 from pyxform.builder import (
     SurveyElementBuilder,

--- a/pyxform/__init__.py
+++ b/pyxform/__init__.py
@@ -4,7 +4,7 @@ pyxform is a Python library designed to make authoring XForms for ODK
 Collect easy.
 """
 
-__version__ = "1.0.3+oc"
+__version__ = "1.0.3.oc"
 
 from pyxform.builder import (
     SurveyElementBuilder,

--- a/pyxform/__init__.py
+++ b/pyxform/__init__.py
@@ -4,7 +4,7 @@ pyxform is a Python library designed to make authoring XForms for ODK
 Collect easy.
 """
 
-__version__ = "1.0.3-oc"
+__version__ = "1.0.3+oc"
 
 from pyxform.builder import (
     SurveyElementBuilder,

--- a/pyxform/__init__.py
+++ b/pyxform/__init__.py
@@ -4,7 +4,7 @@ pyxform is a Python library designed to make authoring XForms for ODK
 Collect easy.
 """
 
-__version__ = "oc-1.0.2"
+__version__ = "1.0.3-oc"
 
 from pyxform.builder import (
     SurveyElementBuilder,

--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -90,6 +90,7 @@ survey_header = {
     "tag": constants.NAME,
     "value": constants.NAME,
     "image": "media::image",
+    "big-image": "media::big-image",
     "audio": "media::audio",
     "video": "media::video",
     "count": "control::jr:count",
@@ -105,6 +106,7 @@ survey_header = {
     "required message": "bind::jr:requiredMsg",
     "body": "control",
     "parameters": "parameters",
+    constants.ENTITIES_SAVETO: "bind::entities:saveto",
 }
 # Key is the pyxform internal name, Value is the name used in error/warning messages.
 TRANSLATABLE_SURVEY_COLUMNS = {
@@ -113,7 +115,7 @@ TRANSLATABLE_SURVEY_COLUMNS = {
     constants.HINT: constants.HINT,
     "guidance_hint": "guidance_hint",
     "image": survey_header["image"],
-    # Per ODK Spec, could include "big-image" once pyxform supports it.
+    "big-image": survey_header["big-image"],
     "audio": survey_header["audio"],
     "video": survey_header["video"],
     "jr:constraintMsg": "constraint_message",
@@ -122,6 +124,7 @@ TRANSLATABLE_SURVEY_COLUMNS = {
 TRANSLATABLE_CHOICES_COLUMNS = {
     "label": constants.LABEL,
     "image": "media::image",
+    "big-image": "media::big-image",
     "audio": "media::audio",
     "video": "media::video",
 }
@@ -130,6 +133,7 @@ list_header = {
     "list_name": constants.LIST_NAME,
     "value": constants.NAME,
     "image": "media::image",
+    "big-image": "media::big-image",
     "audio": "media::audio",
     "video": "media::video",
 }

--- a/pyxform/builder.py
+++ b/pyxform/builder.py
@@ -7,6 +7,7 @@ import os
 import re
 
 from pyxform import file_utils, utils
+from pyxform.entities.entity_declaration import EntityDeclaration
 from pyxform.errors import PyXFormError
 from pyxform.external_instance import ExternalInstance
 from pyxform.question import (
@@ -94,6 +95,7 @@ class SurveyElementBuilder:
         """
         if "add_none_option" in d:
             self._add_none_option = d["add_none_option"]
+
         if d["type"] in self.SECTION_CLASSES:
             section = self._create_section_from_dict(d)
 
@@ -116,6 +118,8 @@ class SurveyElementBuilder:
             return full_survey.children
         elif d["type"] in ["xml-external", "csv-external"]:
             return ExternalInstance(**d)
+        elif d["type"] == "entity":
+            return EntityDeclaration(**d)
         else:
             self._save_trigger_as_setvalue_and_remove_calculate(d)
 

--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -12,6 +12,7 @@ are easier to find.
 TYPE = "type"
 TITLE = "title"
 NAME = "name"
+ENTITIES_SAVETO = "save_to"
 ID_STRING = "id_string"
 SMS_KEYWORD = "sms_keyword"
 SMS_FIELD = "sms_field"
@@ -70,6 +71,7 @@ FIELD_LIST = "field-list"
 SURVEY = "survey"
 SETTINGS = "settings"
 EXTERNAL_CHOICES = "external_choices"
+ENTITIES = "entities"
 
 OSM = "osm"
 OSM_TYPE = "binary"
@@ -83,6 +85,7 @@ SUPPORTED_SHEET_NAMES = [
     SETTINGS,
     EXTERNAL_CHOICES,
     OSM,
+    ENTITIES,
 ]
 XLS_EXTENSIONS = [".xls"]
 XLSX_EXTENSIONS = [".xlsx", ".xlsm"]
@@ -101,6 +104,11 @@ EXTERNAL_INSTANCES = ["calculate", "constraint", "readonly", "required", "releva
 # The ODK XForms version that generated forms comply to
 CURRENT_XFORMS_VERSION = "1.0.0"
 
+# The ODK entities spec version that generated forms comply to
+CURRENT_ENTITIES_VERSION = "2022.1.0"
+ENTITY_RELATED = "entity_related"
+ENTITIES_RESERVED_PREFIX = "__"
+
 DEPRECATED_DEVICE_ID_METADATA_FIELDS = ["subscriberid", "simserial"]
 
 AUDIO_QUALITY_VOICE_ONLY = "voice-only"
@@ -117,6 +125,13 @@ EXTERNAL_CHOICES_ITEMSET_REF_LABEL_GEOJSON = "title"
 EXTERNAL_CHOICES_ITEMSET_REF_VALUE_GEOJSON = "id"
 
 ROW_FORMAT_STRING: str = "[row : %s]"
+
+XML_IDENTIFIER_ERROR_MESSAGE = "must begin with a letter, colon, or underscore. Other characters can include numbers, dashes, and periods."
+_MSG_SUPPRESS_SPELLING = (
+    " If you do not mean to include a sheet, to suppress this message, "
+    "prefix the sheet name with an underscore. For example 'setting' "
+    "becomes '_setting'."
+)
 
 # Custom annotate labels
 ANNOTATE_ITEMGROUP = "Item Group"

--- a/pyxform/entities/entities_parsing.py
+++ b/pyxform/entities/entities_parsing.py
@@ -1,0 +1,102 @@
+from typing import Dict, List
+
+from pyxform import constants
+from pyxform.errors import PyXFormError
+from pyxform.xlsparseutils import find_sheet_misspellings, is_valid_xml_tag
+
+
+def get_entity_declaration(workbook_dict: Dict, warnings: List) -> Dict:
+    entities_sheet = workbook_dict.get(constants.ENTITIES, [])
+
+    if len(entities_sheet) == 0:
+        similar = find_sheet_misspellings(
+            key=constants.ENTITIES, keys=workbook_dict.keys()
+        )
+        if similar is not None:
+            warnings.append(similar + constants._MSG_SUPPRESS_SPELLING)
+        return {}
+    elif len(entities_sheet) > 1:
+        raise PyXFormError(
+            "Currently, you can only declare a single entity per form. Please make sure your entities sheet only declares one entity."
+        )
+
+    entity = entities_sheet[0]
+    dataset = entity["dataset"]
+
+    if dataset.startswith(constants.ENTITIES_RESERVED_PREFIX):
+        raise PyXFormError(
+            f"Invalid dataset name: '{dataset}' starts with reserved prefix {constants.ENTITIES_RESERVED_PREFIX}."
+        )
+
+    if "." in dataset:
+        raise PyXFormError(
+            f"Invalid dataset name: '{dataset}'. Dataset names may not include periods."
+        )
+
+    if not is_valid_xml_tag(dataset):
+        if isinstance(dataset, bytes):
+            dataset = dataset.encode("utf-8")
+
+        raise PyXFormError(
+            f"Invalid dataset name: '{dataset}'. Dataset names must begin with a letter, colon, or underscore. Other characters can include numbers or dashes."
+        )
+
+    if not ("label" in entity):
+        raise PyXFormError("The entities sheet is missing the required label column.")
+
+    creation_condition = entity["create_if"] if "create_if" in entity else "1"
+
+    return {
+        "name": "entity",
+        "type": "entity",
+        "parameters": {
+            "dataset": dataset,
+            "create": creation_condition,
+            "label": entity["label"],
+        },
+    }
+
+
+def validate_entity_saveto(
+    row: Dict, row_number: int, entity_declaration: Dict, in_repeat: bool
+):
+    save_to = row.get("bind", {}).get("entities:saveto", "")
+    if not save_to:
+        return
+
+    if len(entity_declaration) == 0:
+        raise PyXFormError(
+            "To save entity properties using the save_to column, you must add an entities sheet and declare an entity."
+        )
+
+    if constants.GROUP in row.get(constants.TYPE) or constants.REPEAT in row.get(
+        constants.TYPE
+    ):
+        raise PyXFormError(
+            f"{constants.ROW_FORMAT_STRING % row_number} Groups and repeats can't be saved as entity properties."
+        )
+
+    if in_repeat:
+        raise PyXFormError(
+            f"{constants.ROW_FORMAT_STRING % row_number} Currently, you can't create entities from repeats. You may only specify save_to values for form fields outside of repeats."
+        )
+
+    error_start = f"{constants.ROW_FORMAT_STRING % row_number} Invalid save_to name:"
+
+    if save_to == "name" or save_to == "label":
+        raise PyXFormError(
+            f"{error_start} the entity property name '{save_to}' is reserved."
+        )
+
+    if save_to.startswith(constants.ENTITIES_RESERVED_PREFIX):
+        raise PyXFormError(
+            f"{error_start} the entity property name '{save_to}' starts with reserved prefix {constants.ENTITIES_RESERVED_PREFIX}."
+        )
+
+    if not is_valid_xml_tag(save_to):
+        if isinstance(save_to, bytes):
+            save_to = save_to.encode("utf-8")
+
+        raise PyXFormError(
+            f"{error_start} '{save_to}'. Entity property names {constants.XML_IDENTIFIER_ERROR_MESSAGE}"
+        )

--- a/pyxform/entities/entity_declaration.py
+++ b/pyxform/entities/entity_declaration.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from pyxform.survey_element import SurveyElement
+from pyxform.utils import node
+
+
+class EntityDeclaration(SurveyElement):
+    def xml_instance(self, **kwargs):
+        attributes = {}
+        attributes["dataset"] = self.get("parameters", {}).get("dataset", "")
+        attributes["create"] = "1"
+        attributes["id"] = ""
+
+        label_node = node("label")
+        return node("entity", label_node, **attributes)
+
+    def xml_bindings(self):
+        survey = self.get_root()
+
+        create_expr = survey.insert_xpaths(
+            self.get("parameters", {}).get("create", "true()"), context=self
+        )
+        create_bind = {
+            "calculate": create_expr,
+            "type": "string",
+            "readonly": "true()",
+        }
+        create_node = node("bind", nodeset=self.get_xpath() + "/@create", **create_bind)
+
+        id_bind = {"type": "string", "readonly": "true()"}
+        id_node = node("bind", nodeset=self.get_xpath() + "/@id", **id_bind)
+
+        id_setvalue_attrs = {
+            "event": "odk-instance-first-load",
+            "type": "string",
+            "readonly": "true()",
+            "value": "uuid()",
+        }
+        id_setvalue = node("setvalue", ref=self.get_xpath() + "/@id", **id_setvalue_attrs)
+
+        label_expr = survey.insert_xpaths(
+            self.get("parameters", {}).get("label", ""), context=self
+        )
+        label_bind = {
+            "calculate": label_expr,
+            "type": "string",
+            "readonly": "true()",
+        }
+        label_node = node("bind", nodeset=self.get_xpath() + "/label", **label_bind)
+        return [create_node, id_node, id_setvalue, label_node]

--- a/pyxform/json_form_schema.json
+++ b/pyxform/json_form_schema.json
@@ -144,6 +144,15 @@
 									"description" : "A key value pair where the key is a language, and the value is the content uri in that language."
 								}
 							},
+							"big-image" :
+							{
+								"type" : ["object", "string"],
+								"additionalProperties":
+								{
+									"type" : "string",
+									"description" : "A key value pair where the key is a language, and the value is the content uri in that language."
+								}
+							},
 							"audio" :
 							{
 								"type" : ["object", "string"],

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -173,6 +173,7 @@ class Survey(Section):
             "style": str,
             "attribute": dict,
             "namespaces": str,
+            constants.ENTITY_RELATED: str,
         }
     )  # yapf: disable
 
@@ -204,7 +205,9 @@ class Survey(Section):
 
     def get_nsmap(self):
         """Add additional namespaces"""
-        namespaces = getattr(self, constants.NAMESPACES, None)
+        namespaces = getattr(self, constants.NAMESPACES, "")
+        if getattr(self, constants.ENTITY_RELATED, "false") == "true":
+            namespaces += " entities=http://www.opendatakit.org/xforms/entities"
 
         if namespaces and isinstance(namespaces, str):
             nslist = [
@@ -572,13 +575,15 @@ class Survey(Section):
         self._add_empty_translations()
 
         model_kwargs = {"odk:xforms-version": constants.CURRENT_XFORMS_VERSION}
+        if getattr(self, constants.ENTITY_RELATED, "false") == "true":
+            model_kwargs["entities:entities-version"] = constants.CURRENT_ENTITIES_VERSION
 
         model_children = []
         if self._translations:
             model_children.append(self.itext())
         model_children += [node("instance", self.xml_instance())]
         model_children += list(self._generate_instances())
-        model_children += self.xml_bindings()
+        model_children += self.xml_descendent_bindings()
         model_children += self.xml_actions()
 
         if self.submission_url or self.public_key or self.auto_send or self.auto_delete:
@@ -796,7 +801,8 @@ class Survey(Section):
             if parent and not parent.get("choice_filter"):
                 translation_key = survey_element.get_xpath() + ":label"
                 media_dict = survey_element.get("media")
-                _set_up_media_translations(media_dict, translation_key)
+                if isinstance(media_dict, dict):
+                    _set_up_media_translations(media_dict, translation_key)
 
     def itext(self):
         """
@@ -849,7 +855,7 @@ class Survey(Section):
                         itext_nodes.append(
                             node("value", value, toParseString=output_inserted)
                         )
-                    elif media_type == "image":
+                    elif media_type == "image" or media_type == "big-image":
                         if value != "-":
                             itext_nodes.append(
                                 node(

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -14,10 +14,10 @@ from pyxform.utils import (
     BRACKETED_TAG_REGEX,
     INVALID_XFORM_TAG_REGEXP,
     default_is_dynamic,
-    is_valid_xml_tag,
     node,
 )
 from pyxform.xls2json import print_pyobj_to_json
+from pyxform.xlsparseutils import is_valid_xml_tag
 
 if TYPE_CHECKING:
     from typing import List
@@ -153,18 +153,14 @@ class SurveyElement(dict):
     )
 
     # Supported media types for attaching to questions
-    SUPPORTED_MEDIA = ("image", "audio", "video")
+    SUPPORTED_MEDIA = ("image", "big-image", "audio", "video")
 
     def validate(self):
         if not is_valid_xml_tag(self.name):
             invalid_char = re.search(INVALID_XFORM_TAG_REGEXP, self.name)
-            msg = (
-                "The name '{}' is an invalid XML tag, it contains an "
-                "invalid character '{}'. Names must begin with a letter, "
-                "colon, or underscore, subsequent characters can include "
-                "numbers, dashes, and periods".format(self.name, invalid_char.group(0))
+            raise PyXFormError(
+                f"The name '{self.name}' contains an invalid character '{invalid_char.group(0)}'. Names {constants.XML_IDENTIFIER_ERROR_MESSAGE}"
             )
-            raise PyXFormError(msg)
 
     # TODO: Make sure renaming this doesn't cause any problems
     def iter_descendants(self):
@@ -744,15 +740,22 @@ class SurveyElement(dict):
         msg = "The survey element named '%s' " "has no label or hint." % self.name
         if len(result) == 0:
             raise PyXFormError(msg)
+
         # Guidance hint alone is not OK since they may be hidden by default.
         if not any((self.label, self.media, self.hint)) and self.guidance_hint:
             raise PyXFormError(msg)
 
+        # big-image must combine with image
+        if "image" not in self.media and "big-image" in self.media:
+            raise PyXFormError(
+                "To use big-image, you must also specify an image for the survey element named {self.name}."
+            )
+
         return result
 
-    def xml_binding(self):
+    def xml_bindings(self):
         """
-        Return the binding for this survey element.
+        Return the binding(s) for this survey element.
         """
         survey = self.get_root()
         bind_dict = self.bind.copy()
@@ -794,18 +797,18 @@ class SurveyElement(dict):
                 if k == "jr:noAppErrorString" and type(v) is dict:
                     v = "jr:itext('%s')" % self._translation_path("jr:noAppErrorString")
                 bind_dict[k] = survey.insert_xpaths(v, context=self)
-            return node("bind", nodeset=self.get_xpath(), **bind_dict)
+            return [node("bind", nodeset=self.get_xpath(), **bind_dict)]
         return None
 
-    def xml_bindings(self):
+    def xml_descendent_bindings(self):
         """
         Return a list of bindings for this node and all its descendants.
         """
         result = []
         for e in self.iter_descendants():
-            xml_binding = e.xml_binding()
-            if xml_binding is not None:
-                result.append(xml_binding)
+            xml_bindings = e.xml_bindings()
+            if xml_bindings is not None:
+                result.extend(xml_bindings)
 
             # dynamic defaults for repeats go in the body. All other dynamic defaults (setvalue actions) go in the model
             if (

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -460,7 +460,7 @@ class SurveyElement(dict):
                 "required",
             ]:
                 # Prepend * with \
-                attr_value = attr_value.replace("*", "\*")
+                attr_value = attr_value.replace("*", "\*")  # noqa
 
         # Replace { with [
         attr_value = attr_value.replace("{", "[")

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -20,11 +20,6 @@ from pyxform.xls2json_backends import is_empty, xls_value_to_unicode, xlsx_value
 
 SEP = "_"
 
-# http://www.w3.org/TR/REC-xml/
-TAG_START_CHAR = r"[a-zA-Z:_]"
-TAG_CHAR = r"[a-zA-Z:_0-9\-.]"
-XFORM_TAG_REGEXP = "%(start)s%(char)s*" % {"start": TAG_START_CHAR, "char": TAG_CHAR}
-
 INVALID_XFORM_TAG_REGEXP = r"[^a-zA-Z:_][^a-zA-Z:_0-9\-.]*"
 
 LAST_SAVED_INSTANCE_NAME = "__last-saved"
@@ -66,13 +61,6 @@ class PatchedText(Text):
         if data:
             data = data.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
         writer.write(data)
-
-
-def is_valid_xml_tag(tag):
-    """
-    Use a regex to see if there are any invalid characters (i.e. spaces).
-    """
-    return re.search(r"^" + XFORM_TAG_REGEXP + r"$", tag)
 
 
 def node(*args, **kwargs):

--- a/pyxform/validators/pyxform/missing_translations_check.py
+++ b/pyxform/validators/pyxform/missing_translations_check.py
@@ -88,7 +88,7 @@ def find_missing_translations(
     if 0 < len(sheet_data):
         # e.g. ("name", "q1"), ("label", {"en": "Hello", "fr": "Bonjour"})
         for column_type, cell_content in sheet_data[0].items():
-            if column_type == constants.MEDIA:
+            if column_type == constants.MEDIA and isinstance(cell_content, dict):
                 # e.g. ("audio", {"eng": "my.mp3"})
                 for media_type, media_cell in cell_content.items():
                     process_cell(typ=media_type, cell=media_cell)

--- a/pyxform/validators/pyxform/parameters_generic.py
+++ b/pyxform/validators/pyxform/parameters_generic.py
@@ -4,6 +4,9 @@ from pyxform.errors import PyXFormError
 
 PARAMETERS_TYPE = Dict[str, Any]
 
+# Label and value are used to match against user-specified files so case should be preserved.
+CASE_SENSITIVE_VALUES = ["label", "value"]
+
 
 def parse(raw_parameters: str) -> PARAMETERS_TYPE:
     parts = raw_parameters.split(";")
@@ -21,7 +24,7 @@ def parse(raw_parameters: str) -> PARAMETERS_TYPE:
             )
         k, v = param.split("=")[:2]
         key = k.lower().strip()
-        params[key] = v.lower().strip()
+        params[key] = v.strip() if key in CASE_SENSITIVE_VALUES else v.lower().strip()
 
     return params
 

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -8,24 +8,29 @@ import os
 import re
 import sys
 from collections import Counter
-from typing import Any, Dict, KeysView, List, Optional
+from typing import Any, Dict, List
 
 from pyxform import aliases, constants
-from pyxform.constants import EXTERNAL_INSTANCE_EXTENSIONS, ROW_FORMAT_STRING
+from pyxform.constants import (
+    _MSG_SUPPRESS_SPELLING,
+    EXTERNAL_INSTANCE_EXTENSIONS,
+    ROW_FORMAT_STRING,
+    XML_IDENTIFIER_ERROR_MESSAGE,
+)
+from pyxform.entities.entities_parsing import (
+    get_entity_declaration,
+    validate_entity_saveto,
+)
 from pyxform.errors import PyXFormError
-from pyxform.utils import default_is_dynamic, is_valid_xml_tag, levenshtein_distance
+from pyxform.utils import default_is_dynamic
 from pyxform.validators.pyxform import parameters_generic, select_from_file_params
 from pyxform.validators.pyxform.missing_translations_check import (
     missing_translations_check,
 )
 from pyxform.xls2json_backends import csv_to_dict, xls_to_dict, xlsx_to_dict
+from pyxform.xlsparseutils import find_sheet_misspellings, is_valid_xml_tag
 
 SMART_QUOTES = {"\u2018": "'", "\u2019": "'", "\u201c": '"', "\u201d": '"'}
-_MSG_SUPPRESS_SPELLING = (
-    " If you do not mean to include a sheet, to suppress this message, "
-    "prefix the sheet name with an underscore. For example 'setting' "
-    "becomes '_setting'."
-)
 
 
 def print_pyobj_to_json(pyobj, path=None):
@@ -317,34 +322,6 @@ def process_image_default(default_value):
     return default_value
 
 
-def find_sheet_misspellings(key: str, keys: "KeysView") -> "Optional[str]":
-    """
-    Find possible sheet name misspellings to warn the user about.
-
-    It's possible that this will warn about sheet names for sheets that have
-    auxilliary metadata that is not meant for processing by pyxform. For
-    example the "osm" sheet name may be similar to many other initialisms.
-
-    :param key: The sheet name to look for.
-    :param keys: The workbook sheet names.
-    """
-    candidates = tuple(
-        _k  # thanks to black
-        for _k in keys
-        if 2 >= levenshtein_distance(_k.lower(), key)
-        and _k not in constants.SUPPORTED_SHEET_NAMES
-        and not _k.startswith("_")
-    )
-    if 0 < len(candidates):
-        msg = (
-            "When looking for a sheet named '{k}', the following sheets with "
-            "similar names were found: {c}."
-        ).format(k=key, c=str(", ".join(("'{}'".format(c) for c in candidates))))
-        return msg
-    else:
-        return None
-
-
 def workbook_to_json(
     workbook_dict,
     form_name=None,
@@ -559,6 +536,9 @@ def workbook_to_json(
                                     ),
                                 )
                             )  # noqa
+
+    # ########## Entities sheet ###########
+    entity_declaration = get_entity_declaration(workbook_dict, warnings)
 
     # ########## Survey sheet ###########
     survey_sheet = workbook_dict[constants.SURVEY]
@@ -901,13 +881,13 @@ def workbook_to_json(
         if not is_valid_xml_tag(question_name):
             if isinstance(question_name, bytes):
                 question_name = question_name.encode("utf-8")
-            error_message = ROW_FORMAT_STRING % row_number
-            error_message += " Invalid question name [" + question_name + "] "
-            error_message += "Names must begin with a letter, colon," + " or underscore."
-            error_message += (
-                "Subsequent characters can include numbers," + " dashes, and periods."
+
+            raise PyXFormError(
+                f"{ROW_FORMAT_STRING % row_number} Invalid question name '{question_name}'. Names {XML_IDENTIFIER_ERROR_MESSAGE}"
             )
-            raise PyXFormError(error_message)
+
+        in_repeat = any(ancestor["control_type"] == "repeat" for ancestor in stack)
+        validate_entity_saveto(row, row_number, entity_declaration, in_repeat)
 
         # Try to parse question as begin control statement
         # (i.e. begin loop/repeat/group):
@@ -1357,7 +1337,6 @@ def workbook_to_json(
 
             parent_children_array.append(new_dict)
             continue
-
         # TODO: Consider adding some question_type validation here.
 
         # Put the row in the json dict as is:
@@ -1400,6 +1379,10 @@ def workbook_to_json(
                 "type": "calculate",
             }
         )
+
+    if len(entity_declaration) > 0:
+        json_dict[constants.ENTITY_RELATED] = "true"
+        meta_children.append(entity_declaration)
 
     if len(meta_children) > 0:
         meta_element = {

--- a/pyxform/xls2json_backends.py
+++ b/pyxform/xls2json_backends.py
@@ -53,7 +53,7 @@ def trim_trailing_empty(a_list: list, n_empty: int) -> list:
 
 def get_excel_column_headers(first_row: Iterator[Optional[str]]) -> List[Optional[str]]:
     """Get column headers from the first row; stop if there's a run of empty columns."""
-    max_adjacent_empty = 20
+    max_adjacent_empty_columns = 20
     column_header_list = list()
     adjacent_empty_cols = 0
     for column_header in first_row:
@@ -61,7 +61,7 @@ def get_excel_column_headers(first_row: Iterator[Optional[str]]) -> List[Optiona
             # Preserve column order (will filter later)
             column_header_list.append(None)
             # After a run of empty cols, assume we've reached the end of the data.
-            if max_adjacent_empty < adjacent_empty_cols:
+            if max_adjacent_empty_columns < adjacent_empty_cols:
                 break
             adjacent_empty_cols += 1
         else:
@@ -82,7 +82,7 @@ def get_excel_rows(
     cell_func: Callable[[aCell, int, str], Any],
 ) -> List[Dict[str, Any]]:
     """Get rows of cleaned data; stop if there's a run of empty rows."""
-    max_adjacent_empty = 20
+    max_adjacent_empty_rows = 60
     col_header_enum = list(enumerate(headers))
     adjacent_empty_rows = 0
     result_rows = []
@@ -100,7 +100,7 @@ def get_excel_rows(
 
         if 0 == len(row_dict):
             # After a run of empty rows, assume we've reached the end of the data.
-            if max_adjacent_empty < adjacent_empty_rows:
+            if max_adjacent_empty_rows < adjacent_empty_rows:
                 break
             adjacent_empty_rows += 1
         else:

--- a/pyxform/xls2xform.py
+++ b/pyxform/xls2xform.py
@@ -11,10 +11,10 @@ from os.path import splitext
 
 from pyxform import builder, xls2json
 from pyxform.utils import (
-    has_external_choices,
-    sheet_to_csv,
     extract_calculate_elements,
     get_meta_node_index,
+    has_external_choices,
+    sheet_to_csv,
 )
 from pyxform.validators.odk_validate import ODKValidateError
 

--- a/pyxform/xlsparseutils.py
+++ b/pyxform/xlsparseutils.py
@@ -1,0 +1,45 @@
+import re
+from typing import KeysView, Optional
+
+from pyxform import constants
+from pyxform.utils import levenshtein_distance
+
+# http://www.w3.org/TR/REC-xml/
+TAG_START_CHAR = r"[a-zA-Z:_]"
+TAG_CHAR = r"[a-zA-Z:_0-9\-.]"
+XFORM_TAG_REGEXP = "%(start)s%(char)s*" % {"start": TAG_START_CHAR, "char": TAG_CHAR}
+
+
+def find_sheet_misspellings(key: str, keys: "KeysView") -> "Optional[str]":
+    """
+    Find possible sheet name misspellings to warn the user about.
+
+    It's possible that this will warn about sheet names for sheets that have
+    auxilliary metadata that is not meant for processing by pyxform. For
+    example the "osm" sheet name may be similar to many other initialisms.
+
+    :param key: The sheet name to look for.
+    :param keys: The workbook sheet names.
+    """
+    candidates = tuple(
+        _k  # thanks to black
+        for _k in keys
+        if 2 >= levenshtein_distance(_k.lower(), key)
+        and _k not in constants.SUPPORTED_SHEET_NAMES
+        and not _k.startswith("_")
+    )
+    if 0 < len(candidates):
+        msg = (
+            "When looking for a sheet named '{k}', the following sheets with "
+            "similar names were found: {c}."
+        ).format(k=key, c=str(", ".join(("'{}'".format(c) for c in candidates))))
+        return msg
+    else:
+        return None
+
+
+def is_valid_xml_tag(tag):
+    """
+    Use a regex to see if there are any invalid characters (i.e. spaces).
+    """
+    return re.search(r"^" + XFORM_TAG_REGEXP + r"$", tag)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pyxform",
-    version="1.0.3+oc",
+    version="1.0.3.oc",
     author="github.com/xlsform",
     author_email="info@xlsform.org",
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pyxform",
-    version="1.0.3.oc",
+    version="1.0.3+oc",
     author="github.com/xlsform",
     author_email="info@xlsform.org",
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pyxform",
-    version="oc-1.0.2",
+    version="1.0.3-oc",
     author="github.com/xlsform",
     author_email="info@xlsform.org",
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pyxform",
-    version="1.0.3-oc",
+    version="1.0.3+oc",
     author="github.com/xlsform",
     author_email="info@xlsform.org",
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/tests/j2x_question_tests.py
+++ b/tests/j2x_question_tests.py
@@ -16,6 +16,8 @@ def ctw(control):
     ctw stands for control_test_wrap, but ctw is shorter and easier. using
     begin_str and end_str to take out the wrap that xml gives us
     """
+    if isinstance(control, list) and len(control) == 1:
+        control = control[0]
     return control.toxml()
 
 
@@ -55,7 +57,7 @@ class Json2XformQuestionValidationTests(TestCase):
         self.assertEqual(ctw(q.xml_control()), expected_string_control_xml)
 
         if TESTING_BINDINGS:
-            self.assertEqual(ctw(q.xml_binding()), expected_string_binding_xml)
+            self.assertEqual(ctw(q.xml_bindings()), expected_string_binding_xml)
 
     def test_select_one_question_multilingual(self):
         """
@@ -86,7 +88,7 @@ class Json2XformQuestionValidationTests(TestCase):
         self.assertEqual(ctw(q.xml_control()), expected_select_one_control_xml)
 
         if TESTING_BINDINGS:
-            self.assertEqual(ctw(q.xml_binding()), expected_select_one_binding_xml)
+            self.assertEqual(ctw(q.xml_bindings()), expected_select_one_binding_xml)
 
     def test_simple_integer_question_type_multilingual(self):
         """
@@ -114,7 +116,7 @@ class Json2XformQuestionValidationTests(TestCase):
         self.assertEqual(ctw(q.xml_control()), expected_integer_control_xml)
 
         if TESTING_BINDINGS:
-            self.assertEqual(ctw(q.xml_binding()), expected_integer_binding_xml)
+            self.assertEqual(ctw(q.xml_bindings()), expected_integer_binding_xml)
 
     def test_simple_date_question_type_multilingual(self):
         """
@@ -140,7 +142,7 @@ class Json2XformQuestionValidationTests(TestCase):
         self.assertEqual(ctw(q.xml_control()), expected_date_control_xml)
 
         if TESTING_BINDINGS:
-            self.assertEqual(ctw(q.xml_binding()), expected_date_binding_xml)
+            self.assertEqual(ctw(q.xml_bindings()), expected_date_binding_xml)
 
     def test_simple_phone_number_question_type_multilingual(self):
         """
@@ -165,7 +167,7 @@ class Json2XformQuestionValidationTests(TestCase):
         self.assertEqual(ctw(q.xml_control()), expected_phone_number_control_xml)
 
         if TESTING_BINDINGS:
-            self.assertEqual(ctw(q.xml_binding()), expected_phone_number_binding_xml)
+            self.assertEqual(ctw(q.xml_bindings()), expected_phone_number_binding_xml)
 
     def test_simple_select_all_question_multilingual(self):
         """
@@ -195,7 +197,7 @@ class Json2XformQuestionValidationTests(TestCase):
         self.assertEqual(ctw(q.xml_control()), expected_select_all_control_xml)
 
         if TESTING_BINDINGS:
-            self.assertEqual(ctw(q.xml_binding()), expected_select_all_binding_xml)
+            self.assertEqual(ctw(q.xml_bindings()), expected_select_all_binding_xml)
 
     def test_simple_decimal_question_multilingual(self):
         """
@@ -221,4 +223,4 @@ class Json2XformQuestionValidationTests(TestCase):
         self.assertEqual(ctw(q.xml_control()), expected_decimal_control_xml)
 
         if TESTING_BINDINGS:
-            self.assertEqual(ctw(q.xml_binding()), expected_decimal_binding_xml)
+            self.assertEqual(ctw(q.xml_bindings()), expected_decimal_binding_xml)

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -2,8 +2,8 @@
 """
 Annotate label test module.
 """
-from tests.pyxform_test_case import PyxformTestCase
 from pyxform import constants
+from tests.pyxform_test_case import PyxformTestCase
 
 
 class AnnotateLabelTest(PyxformTestCase):
@@ -538,7 +538,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | calculate | check2     |                                       | 2+1         |                   |
             |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} > 1 * 2 |
             """,
-            xml__contains=["[Show When: $[check2] gt 1 \* 2]"],
+            xml__contains=["[Show When: $[check2] gt 1 \* 2]"],  # noqa
             annotate=["all"],
         )
 
@@ -590,7 +590,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | calculate | check2     |                                       | 2+1         |                   |
             |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} > 1 * 3 |
             """,
-            xml__contains=["[Required: $[check2] gt 1 \* 3]"],
+            xml__contains=["[Required: $[check2] gt 1 \* 3]"],  # noqa
             annotate=["all"],
         )
 
@@ -658,7 +658,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | calculate | check2     |                                       | 2+1         |                   |
             |        | note      | info       | This is info:  ${check1} / ${check2}  |             | ${check2} > 1 * 4 |
             """,
-            xml__contains=["[Constraint: $[check2] gt 1 \* 4]"],
+            xml__contains=["[Constraint: $[check2] gt 1 \* 4]"],  # noqa
             annotate=["all"],
         )
 
@@ -685,7 +685,7 @@ class AnnotateLabelTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |           |            |                                       |             |                   |                          |  
+            | survey |           |            |                                       |             |                   |                          |
             |        | type      | name       | label                                 | calculation | constraint        | bind::oc:constraint-type |
             |        | string    | field_name | Event_1                               |             |                   |                          |
             |        | calculate | check1     |                                       | 1+1         |                   |                          |
@@ -701,7 +701,7 @@ class AnnotateLabelTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |           |            |                                       |             |                   |                          |  
+            | survey |           |            |                                       |             |                   |                          |
             |        | type      | name       | label                                 | calculation | constraint        | bind::oc:constraint-type |
             |        | string    | field_name | Event_1                               |             |                   |                          |
             |        | calculate | check1     |                                       | 1+1         |                   |                          |
@@ -726,7 +726,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | calculate | check2     |                                       | 2+1         |               |
             |        | note      | info       | This is info:  ${check1} / ${check2}  |             |               |
             """,
-            xml__contains=["[Default: default\_name]"],
+            xml__contains=["[Default: default\_name]"],  # noqa
             annotate=["all"],
         )
 
@@ -790,7 +790,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | note      | info       | This is info:  ${check1} / ${check2}  |             |               |
             """,
             xml__contains=[
-                '&lt;span style="color: deepskyblue"&gt; [Default: default\_name]&lt;/span&gt;'
+                '&lt;span style="color: deepskyblue"&gt; [Default: default\_name]&lt;/span&gt;'  # noqa
             ],
             annotate=["all"],
         )
@@ -807,7 +807,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | integer | age_visit  | Age at date of visit: | round((decimal-date-time(${date_visit}) - decimal-date-time(${dob})) div 365.25 - .5, 0) |          | yes      |
             """,
             xml__contains=[
-                "[Calculation: round((decimal-date-time($[date\_visit]) - decimal-date-time($[dob])) div 365.25 - .5, 0)]"
+                "[Calculation: round((decimal-date-time($[date\_visit]) - decimal-date-time($[dob])) div 365.25 - .5, 0)]"  # noqa
             ],
             annotate=["all"],
         )
@@ -824,7 +824,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | integer | age_visit  | Age at date of visit: | round((decimal-date-time(${date_visit}) - decimal-date-time(${dob})) div 365.25 - .5, 0) |          | yes      |
             """,
             xml__contains=[
-                '&lt;span style="color: maroon"&gt; [Calculation: round((decimal-date-time($[date\_visit]) - decimal-date-time($[dob])) div 365.25 - .5, 0)]&lt;/span&gt;'
+                '&lt;span style="color: maroon"&gt; [Calculation: round((decimal-date-time($[date\_visit]) - decimal-date-time($[dob])) div 365.25 - .5, 0)]&lt;/span&gt;'  # noqa
             ],
             annotate=["all"],
         )
@@ -896,9 +896,9 @@ class AnnotateLabelTest(PyxformTestCase):
             """,
             xml__contains=[
                 '<input ref="/data/calculate_type_1">',
-                '&lt;span style="color: orangered"&gt; [Name: calculate\_type\_1]&lt;/span&gt;&lt;span style="color: black"&gt; [Type: calculate]&lt;/span&gt;&lt;span style="color: blue"&gt; [Item Group: IG\_1]&lt;/span&gt;&lt;span style="color: maroon"&gt; [Calculation: 1+1]&lt;/span&gt;</label>',
+                '&lt;span style="color: orangered"&gt; [Name: calculate\_type\_1]&lt;/span&gt;&lt;span style="color: black"&gt; [Type: calculate]&lt;/span&gt;&lt;span style="color: blue"&gt; [Item Group: IG\_1]&lt;/span&gt;&lt;span style="color: maroon"&gt; [Calculation: 1+1]&lt;/span&gt;</label>',  # noqa
                 '<input ref="/data/calculate_type_2">',
-                '&lt;span style="color: orangered"&gt; [Name: calculate\_type\_2]&lt;/span&gt;&lt;span style="color: black"&gt; [Type: calculate]&lt;/span&gt;&lt;span style="color: blue"&gt; [Item Group: IG\_2]&lt;/span&gt;&lt;span style="color: maroon"&gt; [Calculation: 2+3]&lt;/span&gt;</label>',
+                '&lt;span style="color: orangered"&gt; [Name: calculate\_type\_2]&lt;/span&gt;&lt;span style="color: black"&gt; [Type: calculate]&lt;/span&gt;&lt;span style="color: blue"&gt; [Item Group: IG\_2]&lt;/span&gt;&lt;span style="color: maroon"&gt; [Calculation: 2+3]&lt;/span&gt;</label>',  # noqa
             ],
             annotate=["all"],
         )
@@ -938,7 +938,7 @@ class AnnotateLabelTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |           |            |                      |          |                                                                                          |               
+            | survey |           |            |                      |          |                                                                                          |
             |        | type      | name       | label                | readonly | calculation                                                                              |
             |        | date      | dob        | Date of Birth:       |          |                                                                                          |
             |        | date      | date_visit | Date of Visit:       |          |                                                                                          |
@@ -953,7 +953,7 @@ class AnnotateLabelTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |           |            |                      |          |                                                                                          |               
+            | survey |           |            |                      |          |                                                                                          |
             |        | type      | name       | label                | readonly | calculation                                                                              |
             |        | date      | dob        | Date of Birth:       |          |                                                                                          |
             |        | date      | date_visit | Date of Visit:       |          |                                                                                          |
@@ -1074,7 +1074,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |          | choices1            | 1       | One    |                |
             |          | choices1            | 2       | Two    |                |
             """,
-            xml__contains=["[Choice Filter: $[int\_num] gt 1]"],
+            xml__contains=["[Choice Filter: $[int\_num] gt 1]"],  # noqa
             annotate=["all"],
         )
 
@@ -1092,7 +1092,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |          | choices1            | 2       | Two    |                |
             """,
             xml__contains=[
-                '&lt;span style="color: dodgerblue"&gt; [Choice Filter: $[int\_num] gt 1]&lt;/span&gt;'
+                '&lt;span style="color: dodgerblue"&gt; [Choice Filter: $[int\_num] gt 1]&lt;/span&gt;'  # noqa
             ],
             annotate=["all"],
         )
@@ -1168,7 +1168,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | type      | name            | label       | video          |
             |        | text      | text_with_video | video Text: | video_file.mp3 |
             """,
-            xml__contains=["[Video: video\_file.mp3]"],
+            xml__contains=["[Video: video\_file.mp3]"],  # noqa
             annotate=["all"],
         )
 
@@ -1182,7 +1182,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | text      | text_with_video | video Text: | video_file.mp3 |
             """,
             xml__contains=[
-                '&lt;span style="color: darkviolet"&gt; [Video: video\_file.mp3]&lt;/span&gt;'
+                '&lt;span style="color: darkviolet"&gt; [Video: video\_file.mp3]&lt;/span&gt;'  # noqa
             ],
             annotate=["all"],
         )
@@ -1196,7 +1196,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | type      | name            | label       | audio          |
             |        | text      | text_with_audio | Audio Text: | audio_file.mp3 |
             """,
-            xml__contains=["[Audio: audio\_file.mp3]"],
+            xml__contains=["[Audio: audio\_file.mp3]"],  # noqa
             annotate=["all"],
         )
 
@@ -1210,7 +1210,7 @@ class AnnotateLabelTest(PyxformTestCase):
             |        | text      | text_with_audio | Audio Text: | audio_file.mp3 |
             """,
             xml__contains=[
-                '&lt;span style="color: darkviolet"&gt; [Audio: audio\_file.mp3]&lt;/span&gt;'
+                '&lt;span style="color: darkviolet"&gt; [Audio: audio\_file.mp3]&lt;/span&gt;'  # noqa
             ],
             annotate=["all"],
         )

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,338 @@
+# -*- coding: utf-8 -*-
+from tests.pyxform_test_case import PyxformTestCase
+
+
+class EntitiesTest(PyxformTestCase):
+    def test_basic_entity_creation_building_blocks(self):
+        self.assertPyxformXform(
+            name="data",
+            debug=True,
+            md="""
+            | survey   |         |       |       |
+            |          | type    | name  | label |
+            |          | text    | a     | A     |
+            | entities |         |       |       |
+            |          | dataset | label |       |
+            |          | trees   | a     |       |
+            """,
+            xml__xpath_match=[
+                "/h:html/h:head/x:model/x:instance/x:data/x:meta/x:entity",
+                '/h:html/h:head/x:model/x:instance/x:data/x:meta/x:entity[@dataset = "trees"]',
+                # defaults to always creating
+                '/h:html/h:head/x:model/x:instance/x:data/x:meta/x:entity[@create = "1"]',
+                '/h:html/h:head/x:model/x:instance/x:data/x:meta/x:entity[@id = ""]',
+                '/h:html/h:head/x:model/x:bind[@nodeset = "/data/meta/entity/@id" and @type = "string" and @readonly = "true()"]',
+                '/h:html/h:head/x:model/x:setvalue[@event = "odk-instance-first-load" and @type = "string" and @ref = "/data/meta/entity/@id" and @value = "uuid()"]',
+                "/h:html/h:head/x:model/x:instance/x:data/x:meta/x:entity/x:label",
+                '/h:html/h:head/x:model/x:bind[@nodeset = "/data/meta/entity/label" and @type = "string" and @readonly = "true()" and @calculate = "a"]',
+                '/h:html/h:head/x:model[@entities:entities-version = "2022.1.0"]',
+            ],
+            xml__contains=['xmlns:entities="http://www.opendatakit.org/xforms/entities"'],
+        )
+
+    def test_multiple_dataset_rows_in_entities_sheet__errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |      |       |
+            |          | type    | name | label |
+            |          | text    | a    | A     |
+            | entities |         |      |       |
+            |          | dataset |      |       |
+            |          | trees   |      |       |
+            |          | shovels |      |       |
+            """,
+            errored=True,
+            error__contains=[
+                "Currently, you can only declare a single entity per form. Please make sure your entities sheet only declares one entity."
+            ],
+        )
+
+    def test_dataset_with_reserved_prefix__errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |
+            |          | type    | name  | label |
+            |          | text    | a     | A     |
+            | entities |         |       |       |
+            |          | dataset | label |       |
+            |          | __sweet | a     |       |
+            """,
+            errored=True,
+            error__contains=[
+                "Invalid dataset name: '__sweet' starts with reserved prefix __."
+            ],
+        )
+
+    def test_dataset_with_invalid_xml_name__errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |
+            |          | type    | name  | label |
+            |          | text    | a     | A     |
+            | entities |         |       |       |
+            |          | dataset | label |       |
+            |          | $sweet  | a     |       |
+            """,
+            errored=True,
+            error__contains=[
+                "Invalid dataset name: '$sweet'. Dataset names must begin with a letter, colon, or underscore. Other characters can include numbers or dashes."
+            ],
+        )
+
+    def test_dataset_with_period_in_name__errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |
+            |          | type    | name  | label |
+            |          | text    | a     | A     |
+            | entities |         |       |       |
+            |          | dataset | label |       |
+            |          | s.w.eet | a     |       |
+            """,
+            errored=True,
+            error__contains=[
+                "Invalid dataset name: 's.w.eet'. Dataset names may not include periods."
+            ],
+        )
+
+    def test_worksheet_name_close_to_entities__produces_warning(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |
+            |          | type    | name  | label |
+            |          | text    | a     | A     |
+            | entitoes |         |       |       |
+            |          | dataset | label |       |
+            |          | trees   | a     |       |
+            """,
+            warnings__contains=[
+                "When looking for a sheet named 'entities', the following sheets with similar names were found: 'entitoes'."
+            ],
+        )
+
+    def test_create_if_in_entities_sheet__puts_expression_on_bind(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |                      |       |
+            |          | type    | name                 | label |
+            |          | text    | a                    | A     |
+            | entities |         |                      |       |
+            |          | dataset | create_if            | label |
+            |          | trees   | string-length(a) > 3 | a     |
+            """,
+            xml__xpath_match=[
+                '/h:html/h:head/x:model/x:bind[@nodeset = "/data/meta/entity/@create" and @calculate = "string-length(a) > 3"]',
+                '/h:html/h:head/x:model/x:instance/x:data/x:meta/x:entity[@create = "1"]',
+            ],
+        )
+
+    def test_label_and_create_if_in_entities_sheet__expand_node_selectors_to_xpath(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |                         |
+            |          | type    | name  | label                   |
+            |          | text    | a     | A                       |
+            | entities |         |       |                         |
+            |          | dataset | label | create_if               |
+            |          | trees   | ${a}  | string-length(${a}) > 3 |
+            """,
+            xml__xpath_match=[
+                '/h:html/h:head/x:model/x:bind[@nodeset = "/data/meta/entity/@create" and @calculate = "string-length( /data/a ) > 3"]',
+                '/h:html/h:head/x:model/x:bind[@nodeset = "/data/meta/entity/label" and @type = "string" and @readonly = "true()" and @calculate = " /data/a "]',
+            ],
+        )
+
+    def test_entity_label__required(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |
+            |          | type    | name  | label |
+            |          | text    | a     | A     |
+            | entities |         |       |       |
+            |          | dataset |       |       |
+            |          | trees   |       |       |
+            """,
+            errored=True,
+            error__contains=["The entities sheet is missing the required label column."],
+        )
+
+    def test_entities_namespace__omitted_if_no_entities_sheet(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |
+            |          | type    | name  | label |
+            |          | text    | a     | A     |
+            """,
+            xml__excludes=['xmlns:entities="http://www.opendatakit.org/xforms/entities"'],
+        )
+
+    def test_entities_version__omitted_if_no_entities_sheet(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |
+            |          | type    | name  | label |
+            |          | text    | a     | A     |
+            """,
+            xml__excludes=['entities:entities-version = "2022.1.0"'],
+        )
+
+    def test_saveto_column__added_to_xml(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |         |
+            |          | type    | name  | label | save_to |
+            |          | text    | a     | A     | foo     |
+            | entities |         |       |       |         |
+            |          | dataset | label |       |         |
+            |          | trees   | a     |       |         |
+            """,
+            xml__xpath_match=[
+                '/h:html/h:head/x:model/x:bind[@nodeset = "/data/a" and @entities:saveto = "foo"]'
+            ],
+        )
+
+    def test_saveto_without_entities_sheet__errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |         |
+            |          | type    | name  | label | save_to |
+            |          | text    | a     | A     | foo     |
+            """,
+            errored=True,
+            error__contains=[
+                "To save entity properties using the save_to column, you must add an entities sheet and declare an entity."
+            ],
+        )
+
+    def test_name_in_saveto_column__errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |         |
+            |          | type    | name  | label | save_to |
+            |          | text    | a     | A     | name    |
+            | entities |         |       |       |         |
+            |          | dataset | label |       |         |
+            |          | trees   | a     |       |         |
+            """,
+            errored=True,
+            error__contains=[
+                "[row : 2] Invalid save_to name: the entity property name 'name' is reserved."
+            ],
+        )
+
+    def test_label_in_saveto_column__errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |         |
+            |          | type    | name  | label | save_to |
+            |          | text    | a     | A     | label   |
+            | entities |         |       |       |         |
+            |          | dataset | label |       |         |
+            |          | trees   | a     |       |         |
+            """,
+            errored=True,
+            error__contains=[
+                "[row : 2] Invalid save_to name: the entity property name 'label' is reserved."
+            ],
+        )
+
+    def test_system_prefix_in_saveto_column__errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |         |
+            |          | type    | name  | label | save_to |
+            |          | text    | a     | A     | __a     |
+            | entities |         |       |       |         |
+            |          | dataset | label |       |         |
+            |          | trees   | a     |       |         |
+            """,
+            errored=True,
+            error__contains=[
+                "[row : 2] Invalid save_to name: the entity property name '__a' starts with reserved prefix __."
+            ],
+        )
+
+    def test_invalid_xml_identifier_in_saveto_column__errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |         |
+            |          | type    | name  | label | save_to |
+            |          | text    | a     | A     | $a      |
+            | entities |         |       |       |         |
+            |          | dataset | label |       |         |
+            |          | trees   | a     |       |         |
+            """,
+            errored=True,
+            error__contains=[
+                "[row : 2] Invalid save_to name: '$a'. Entity property names must begin with a letter, colon, or underscore. Other characters can include numbers, dashes, and periods."
+            ],
+        )
+
+    def test_saveto_on_group__errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |             |       |       |         |
+            |          | type        | name  | label | save_to |
+            |          | begin_group | a     | A     | a       |
+            |          | end_group   |       |       |         |
+            | entities |             |       |       |         |
+            |          | dataset     | label |       |         |
+            |          | trees       | a     |       |         |
+            """,
+            errored=True,
+            error__contains=[
+                "[row : 2] Groups and repeats can't be saved as entity properties."
+            ],
+        )
+
+    def test_saveto_in_repeat__errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |             |        |       |         |
+            |          | type        | name   | label | save_to |
+            |          | begin_repeat| a      | A     |         |
+            |          | text        | size   | Size  | size    |
+            |          | end_repeat  |        |       |         |
+            | entities |             |        |       |         |
+            |          | dataset     | label  |       |         |
+            |          | trees       | ${size}|       |         |
+            """,
+            errored=True,
+            error__contains=[
+                "[row : 3] Currently, you can't create entities from repeats. You may only specify save_to values for form fields outside of repeats."
+            ],
+        )
+
+    def test_saveto_in_group__works(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |             |        |       |         |
+            |          | type        | name   | label | save_to |
+            |          | begin_group | a      | A     |         |
+            |          | text        | size   | Size  | size    |
+            |          | end_group  |        |       |         |
+            | entities |             |        |       |         |
+            |          | dataset     | label  |       |         |
+            |          | trees       | ${size}|       |         |
+            """,
+            errored=False,
+        )

--- a/tests/test_external_instances_for_selects.py
+++ b/tests/test_external_instances_for_selects.py
@@ -242,6 +242,24 @@ class TestSelectFromFile(PyxformTestCase):
                             error__contains=[msg],
                         )
 
+    def test_param_value_case_preserved(self):
+        """Should find that parameters value/label override the default itemset name/label with case preserved."""
+        md = """
+        | survey |                                        |         |         |                      |
+        |        | type                                   | name    | label   | parameters           |
+        |        | select_one_from_file cities{ext}       | city    | City    | value=VAL, label=lBl |
+        """
+        for ext, xp_city, xp_subs in self.xp_test_args:
+            with self.subTest(msg=ext):
+                self.assertPyxformXform(
+                    name="test",
+                    md=md.format(ext=ext),
+                    xml__xpath_match=[
+                        xp_city.model_external_instance_and_bind(),
+                        xp_city.body_itemset_nodeset_and_refs(value="VAL", label="lBl"),
+                    ],
+                )
+
 
 class TestSelectOneExternal(PyxformTestCase):
     """

--- a/tests/test_sheet_columns.py
+++ b/tests/test_sheet_columns.py
@@ -29,7 +29,7 @@ class InvalidSurveyColumnsTests(PyxformTestCase):
             errored=False,
         )
 
-    def test_missing_label(self):
+    def test_label_or_hint__must_be_provided(self):
         self.assertPyxformXform(
             name="invalidcols",
             ss_structure={"survey": [{"type": "text", "name": "q1"}]},
@@ -61,6 +61,29 @@ class InvalidSurveyColumnsTests(PyxformTestCase):
             |        | text | c    |       | m.png        |      |
             """,
             xml__contains=prep_for_xml_contains(expected),
+        )
+
+    def test_big_image_invalid_if_no_image(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |      |      |                  |
+            |        | type | name | media::big-image |
+            |        | text | c    | m.png            |
+            """,
+            errored=True,
+            error__contains=["must also specify an image"],
+        )
+
+    def test_media_column__is_ignored(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |      |      |       |
+            |        | type | name | media |
+            |        | text | c    | m.png |
+            """,
+            xml__excludes=["m.png"],
         )
 
     def test_column_case(self):
@@ -158,12 +181,7 @@ class InvalidChoiceSheetColumnsTests(PyxformTestCase):
 
     def test_clear_filename_error_message(self):
         """Test clear filename error message"""
-        error_message = (
-            "The name 'bad@filename' is an invalid XML tag, it "
-            "contains an invalid character '@'. Names must begin"
-            " with a letter, colon, or underscore, subsequent "
-            "characters can include numbers, dashes, and periods"
-        )
+        error_message = "The name 'bad@filename' contains an invalid character '@'. Names must begin with a letter, colon, or underscore. Other characters can include numbers, dashes, and periods."
         self.assertPyxformXform(
             name="bad@filename",
             ss_structure=self._simple_choice_ss(

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -737,10 +737,10 @@ class TestTranslationsSurvey(PyxformTestCase):
             xml__xpath_match=[
                 self.xp.question_label_references_itext(),
                 self.xp.question_itext_like_label(
-                    "english", "Show When: $[select\_1\_s] = 1"
+                    "english", "Show When: $[select\_1\_s] = 1"  # noqa
                 ),
                 self.xp.question_itext_like_label(
-                    "indonesian", "Show When: $[select\_1\_s] = 2"
+                    "indonesian", "Show When: $[select\_1\_s] = 2"  # noqa
                 ),
             ],
             annotate=["all"],
@@ -784,10 +784,10 @@ class TestTranslationsSurvey(PyxformTestCase):
             xml__xpath_match=[
                 self.xp.question_label_references_itext(),
                 self.xp.question_itext_like_label(
-                    "english", "Constraint: $[select\_1\_s] = 1"
+                    "english", "Constraint: $[select\_1\_s] = 1"  # noqa
                 ),
                 self.xp.question_itext_like_label(
-                    "indonesian", "Constraint: $[select\_1\_s] = 2"
+                    "indonesian", "Constraint: $[select\_1\_s] = 2"  # noqa
                 ),
             ],
             annotate=["all"],

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -103,6 +103,7 @@ class XPathHelper:
         prefix = {
             "audio": ("label", "jr://audio/"),
             "image": ("label", "jr://images/"),
+            "big-image": ("label", "jr://images/"),
             "video": ("label", "jr://video/"),
             "guidance": ("hint", ""),
         }
@@ -137,6 +138,7 @@ class XPathHelper:
         prefix = {
             "audio": ("label", "jr://audio/"),
             "image": ("label", "jr://images/"),
+            "big-image": ("label", "jr://images/"),
             "video": ("label", "jr://video/"),
             "guidance": ("hint", ""),
         }
@@ -173,6 +175,7 @@ class XPathHelper:
         prefix = {
             "audio": "jr://audio/",
             "image": "jr://images/",
+            "big-image": "jr://images/",
             "video": "jr://video/",
         }
         return f"""
@@ -196,6 +199,7 @@ class XPathHelper:
         prefix = {
             "audio": "jr://audio/",
             "image": "jr://images/",
+            "big-image": "jr://images/",
             "video": "jr://video/",
         }
         return f"""
@@ -236,6 +240,7 @@ class XPathHelper:
         prefix = {
             "audio": "jr://audio/",
             "image": "jr://images/",
+            "big-image": "jr://images/",
             "video": "jr://video/",
         }
         return f"""
@@ -609,6 +614,24 @@ class TestTranslationsSurvey(PyxformTestCase):
             warnings_count=0,
         )
 
+    def test_no_default__no_translation__image_with_big_image(self):
+        """Should find default language translations for image and big-image."""
+        md = """
+        | survey |      |      |              |                  |
+        |        | type | name | media::image | media::big-image |
+        |        | note | n1   | greeting.jpg | greeting.jpg     |
+        """
+        self.assertPyxformXform(
+            name="test",
+            md=md,
+            xml__xpath_match=[
+                self.xp.question_itext_form(DEFAULT_LANG, "image", "greeting.jpg"),
+                self.xp.question_itext_form(DEFAULT_LANG, "big-image", "greeting.jpg"),
+                self.xp.language_is_default(DEFAULT_LANG),
+            ],
+            warnings_count=0,
+        )
+
     def test_no_default__one_translation__label_and_hint(self):
         """Should find language translations for label and hint."""
         md = """
@@ -837,9 +860,9 @@ class TestTranslationsSurvey(PyxformTestCase):
     def test_no_default__one_translation__label_and_hint_all_cols(self):
         """Should find language translation for label, hint, and all translatables."""
         md = """
-        | survey |      |      |            |            |                    |                   |                   |                   |                         |                       |
-        |        | type | name | label::eng | hint::eng  | guidance_hint::eng | media::image::eng | media::video::eng | media::audio::eng | constraint_message::eng | required_message::eng |
-        |        | note | n1   | hello      | salutation | greeting           | greeting.jpg      | greeting.mkv      | greeting.mp3      | check me                | mandatory             |
+        | survey |      |      |            |            |                    |                   |                       |                   |                   |                         |                       |
+        |        | type | name | label::eng | hint::eng  | guidance_hint::eng | media::image::eng | media::big-image::eng | media::video::eng | media::audio::eng | constraint_message::eng | required_message::eng |
+        |        | note | n1   | hello      | salutation | greeting           | greeting.jpg      | greeting.jpg          | greeting.mkv      | greeting.mp3      | check me                | mandatory             |
         """
         self.assertPyxformXform(
             name="test",
@@ -851,6 +874,7 @@ class TestTranslationsSurvey(PyxformTestCase):
                 self.xp.question_itext_hint("eng", "salutation"),
                 self.xp.question_itext_form("eng", "guidance", "greeting"),
                 self.xp.question_itext_form("eng", "image", "greeting.jpg"),
+                self.xp.question_itext_form("eng", "big-image", "greeting.jpg"),
                 self.xp.question_itext_form("eng", "video", "greeting.mkv"),
                 self.xp.question_itext_form("eng", "audio", "greeting.mp3"),
                 self.xp.constraint_msg_references_itext(),
@@ -914,9 +938,9 @@ class TestTranslationsSurvey(PyxformTestCase):
     def test_missing_translation__one_lang_all_cols__warn__no_default(self):
         """Should warn if there's multiple missing translations and no default_language."""
         md = """
-        | survey |      |      |       |            |            |                    |                   |                   |                   |                         |                       |
-        |        | type | name | label | label::eng | hint::eng  | guidance_hint::eng | media::image::eng | media::video::eng | media::audio::eng | constraint_message::eng | required_message::eng |
-        |        | note | n1   | hello | hi there   | salutation | greeting           | greeting.jpg      | greeting.mkv      | greeting.mp3      | check me                | mandatory             |
+        | survey |      |      |       |            |            |                    |                   |                       |                   |                   |                         |                       |
+        |        | type | name | label | label::eng | hint::eng  | guidance_hint::eng | media::image::eng | media::big-image::eng | media::video::eng | media::audio::eng | constraint_message::eng | required_message::eng |
+        |        | note | n1   | hello | hi there   | salutation | greeting           | greeting.jpg      | greeting.jpg          | greeting.mkv      | greeting.mp3      | check me                | mandatory             |
         """
         cols = {
             SURVEY: {
@@ -924,6 +948,7 @@ class TestTranslationsSurvey(PyxformTestCase):
                     "hint",
                     "guidance_hint",
                     "media::image",
+                    "media::big-image",
                     "media::video",
                     "media::audio",
                     "constraint_message",
@@ -947,6 +972,8 @@ class TestTranslationsSurvey(PyxformTestCase):
                 self.xp.question_itext_form(DEFAULT_LANG, "guidance", "-"),
                 self.xp.question_itext_form("eng", "image", "greeting.jpg"),
                 self.xp.question_no_itext_form(DEFAULT_LANG, "image", "greeting.jpg"),
+                self.xp.question_itext_form("eng", "big-image", "greeting.jpg"),
+                self.xp.question_no_itext_form(DEFAULT_LANG, "big-image", "greeting.jpg"),
                 self.xp.question_itext_form("eng", "video", "greeting.mkv"),
                 self.xp.question_no_itext_form(DEFAULT_LANG, "video", "greeting.mkv"),
                 self.xp.question_itext_form("eng", "audio", "greeting.mp3"),
@@ -968,9 +995,9 @@ class TestTranslationsSurvey(PyxformTestCase):
         | settings |                  |
         |          | default_language |
         |          | eng              |
-        | survey |      |      |       |            |            |                    |                   |                   |                   |                         |                       |
-        |        | type | name | label | label::eng | hint::eng  | guidance_hint::eng | media::image::eng | media::video::eng | media::audio::eng | constraint_message::eng | required_message::eng |
-        |        | note | n1   | hello | hi there   | salutation | greeting           | greeting.jpg      | greeting.mkv      | greeting.mp3      | check me                | mandatory             |
+        | survey |      |      |       |            |            |                    |                   |                       |                   |                   |                         |                       |
+        |        | type | name | label | label::eng | hint::eng  | guidance_hint::eng | media::image::eng | media::big-image::eng | media::video::eng | media::audio::eng | constraint_message::eng | required_message::eng |
+        |        | note | n1   | hello | hi there   | salutation | greeting           | greeting.jpg      | greeting.jpg          | greeting.mkv      | greeting.mp3      | check me                | mandatory             |
         """
         # cols = {
         #     SURVEY: {
@@ -1191,10 +1218,10 @@ class TestTranslationsChoices(PyxformTestCase):
         | survey  |               |       |            |
         |         | type          | name  | label      |
         |         | select_one c1 | q1    | Question 1 |
-        | choices |           |      |       |              |              |              |
-        |         | list name | name | label | media::audio | media::image | media::video |
-        |         | c1        | na   | la    | a.mp3        | a.jpg        | a.mkv        |
-        |         | c1        | nb   | lb    | b.mp3        | b.jpg        | b.mkv        |
+        | choices |           |      |       |              |              |                  |              |
+        |         | list name | name | label | media::audio | media::image | media::big-image | media::video |
+        |         | c1        | na   | la    | a.mp3        | a.jpg        | a.jpg            | a.mkv        |
+        |         | c1        | nb   | lb    | b.mp3        | b.jpg        | b.jpg            | b.mkv        |
         """
         xpath_match = [
             self.xp.question_label_in_body("Question 1"),
@@ -1205,10 +1232,12 @@ class TestTranslationsChoices(PyxformTestCase):
             self.xp.choice_itext_label(DEFAULT_LANG, "na", "la"),
             self.xp.choice_itext_form(DEFAULT_LANG, "na", "audio", "a.mp3"),
             self.xp.choice_itext_form(DEFAULT_LANG, "na", "image", "a.jpg"),
+            self.xp.choice_itext_form(DEFAULT_LANG, "na", "big-image", "a.jpg"),
             self.xp.choice_itext_form(DEFAULT_LANG, "na", "video", "a.mkv"),
             self.xp.choice_itext_label(DEFAULT_LANG, "nb", "lb"),
             self.xp.choice_itext_form(DEFAULT_LANG, "nb", "audio", "b.mp3"),
             self.xp.choice_itext_form(DEFAULT_LANG, "nb", "image", "b.jpg"),
+            self.xp.choice_itext_form(DEFAULT_LANG, "nb", "big-image", "b.jpg"),
             self.xp.choice_itext_form(DEFAULT_LANG, "nb", "video", "b.mkv"),
         ]
         self.assertPyxformXform(
@@ -1223,10 +1252,10 @@ class TestTranslationsChoices(PyxformTestCase):
         | survey  |               |       |            |
         |         | type          | name  | label      |
         |         | select_one c1 | q1    | Question 1 |
-        | choices |           |      |                 |                        |                        |                        |
-        |         | list name | name | label::Eng (en) | media::audio::Eng (en) | media::image::Eng (en) | media::video::Eng (en) |
-        |         | c1        | na   | la              | a.mp3                  | a.jpg                  | a.mkv                  |
-        |         | c1        | nb   | lb              | b.mp3                  | b.jpg                  | b.mkv                  |
+        | choices |           |      |                 |                        |                        |                            |                        |
+        |         | list name | name | label::Eng (en) | media::audio::Eng (en) | media::image::Eng (en) | media::big-image::Eng (en) | media::video::Eng (en) |
+        |         | c1        | na   | la              | a.mp3                  | a.jpg                  | a.jpg                      | a.mkv                  |
+        |         | c1        | nb   | lb              | b.mp3                  | b.jpg                  | b.jpg                      | b.mkv                  |
         """
         xpath_match = [
             self.xp.question_label_in_body("Question 1"),
@@ -1237,10 +1266,12 @@ class TestTranslationsChoices(PyxformTestCase):
             self.xp.choice_itext_label("Eng (en)", "na", "la"),
             self.xp.choice_itext_form("Eng (en)", "na", "audio", "a.mp3"),
             self.xp.choice_itext_form("Eng (en)", "na", "image", "a.jpg"),
+            self.xp.choice_itext_form("Eng (en)", "na", "big-image", "a.jpg"),
             self.xp.choice_itext_form("Eng (en)", "na", "video", "a.mkv"),
             self.xp.choice_itext_label("Eng (en)", "nb", "lb"),
             self.xp.choice_itext_form("Eng (en)", "nb", "audio", "b.mp3"),
             self.xp.choice_itext_form("Eng (en)", "nb", "image", "b.jpg"),
+            self.xp.choice_itext_form("Eng (en)", "nb", "big-image", "b.jpg"),
             self.xp.choice_itext_form("Eng (en)", "nb", "video", "b.mkv"),
         ]
         self.assertPyxformXform(
@@ -1255,10 +1286,10 @@ class TestTranslationsChoices(PyxformTestCase):
         | survey  |               |       |            |               |
         |         | type          | name  | label      | choice_filter |
         |         | select_one c1 | q1    | Question 1 | q1 != ''      |
-        | choices |           |      |       |              |              |              |
-        |         | list name | name | label | media::audio | media::image | media::video |
-        |         | c1        | na   | la    | a.mp3        | a.jpg        | a.mkv        |
-        |         | c1        | nb   | lb    | b.mp3        | b.jpg        | b.mkv        |
+        | choices |           |      |       |              |              |                  |
+        |         | list name | name | label | media::audio | media::image | media::big-image | media::video |
+        |         | c1        | na   | la    | a.mp3        | a.jpg        | a.jpg            | a.mkv        |
+        |         | c1        | nb   | lb    | b.mp3        | b.jpg        | b.jpg            | b.mkv        |
         """
         xpath_match = [
             self.xp.question_label_in_body("Question 1"),
@@ -1268,10 +1299,16 @@ class TestTranslationsChoices(PyxformTestCase):
             self.xp.choice_instance_itext_label(DEFAULT_LANG, "c1", "la", 0),
             self.xp.choice_instance_itext_form(DEFAULT_LANG, "c1", "audio", "a.mp3", 0),
             self.xp.choice_instance_itext_form(DEFAULT_LANG, "c1", "image", "a.jpg", 0),
+            self.xp.choice_instance_itext_form(
+                DEFAULT_LANG, "c1", "big-image", "a.jpg", 0
+            ),
             self.xp.choice_instance_itext_form(DEFAULT_LANG, "c1", "video", "a.mkv", 0),
             self.xp.choice_instance_itext_label(DEFAULT_LANG, "c1", "lb", 1),
             self.xp.choice_instance_itext_form(DEFAULT_LANG, "c1", "audio", "b.mp3", 1),
             self.xp.choice_instance_itext_form(DEFAULT_LANG, "c1", "image", "b.jpg", 1),
+            self.xp.choice_instance_itext_form(
+                DEFAULT_LANG, "c1", "big-image", "b.jpg", 1
+            ),
             self.xp.choice_instance_itext_form(DEFAULT_LANG, "c1", "video", "b.mkv", 1),
         ]
         self.assertPyxformXform(
@@ -1286,10 +1323,10 @@ class TestTranslationsChoices(PyxformTestCase):
         | survey  |               |       |            |               |
         |         | type          | name  | label      | choice_filter |
         |         | select_one c1 | q1    | Question 1 | q1 != ''      |
-        | choices |           |      |                 |                        |                        |                        |
-        |         | list name | name | label::Eng (en) | media::audio::Eng (en) | media::image::Eng (en) | media::video::Eng (en) |
-        |         | c1        | na   | la              | a.mp3                  | a.jpg                  | a.mkv                  |
-        |         | c1        | nb   | lb              | b.mp3                  | b.jpg                  | b.mkv                  |
+        | choices |           |      |                 |                        |                        |                            |                        |
+        |         | list name | name | label::Eng (en) | media::audio::Eng (en) | media::image::Eng (en) | media::big-image::Eng (en) | media::video::Eng (en) |
+        |         | c1        | na   | la              | a.mp3                  | a.jpg                  | a.jpg                      | a.mkv                  |
+        |         | c1        | nb   | lb              | b.mp3                  | b.jpg                  | b.jpg                      | b.mkv                  |
         """
         xpath_match = [
             self.xp.question_label_in_body("Question 1"),
@@ -1299,10 +1336,12 @@ class TestTranslationsChoices(PyxformTestCase):
             self.xp.choice_instance_itext_label("Eng (en)", "c1", "la", 0),
             self.xp.choice_instance_itext_form("Eng (en)", "c1", "audio", "a.mp3", 0),
             self.xp.choice_instance_itext_form("Eng (en)", "c1", "image", "a.jpg", 0),
+            self.xp.choice_instance_itext_form("Eng (en)", "c1", "big-image", "a.jpg", 0),
             self.xp.choice_instance_itext_form("Eng (en)", "c1", "video", "a.mkv", 0),
             self.xp.choice_instance_itext_label("Eng (en)", "c1", "lb", 1),
             self.xp.choice_instance_itext_form("Eng (en)", "c1", "audio", "b.mp3", 1),
             self.xp.choice_instance_itext_form("Eng (en)", "c1", "image", "b.jpg", 1),
+            self.xp.choice_instance_itext_form("Eng (en)", "c1", "big-image", "b.jpg", 1),
             self.xp.choice_instance_itext_form("Eng (en)", "c1", "video", "b.mkv", 1),
         ]
         self.assertPyxformXform(
@@ -1391,14 +1430,15 @@ class TestTranslationsChoices(PyxformTestCase):
         |         | type          | name  | label      |
         |         | select_one c1 | q1    | Question 1 |
         | choices |           |      |                 |
-        |         | list name | name | label | label::eng | media::audio::eng | media::image::eng | media::video::eng |
-        |         | c1        | na   | la-d  | la-e       | la-d.mp3          | la-d.jpg          | la-d.mkv          |
-        |         | c1        | nb   | lb-d  | lb-e       | lb-d.mp3          | lb-d.jpg          | lb-d.mkv          |
+        |         | list name | name | label | label::eng | media::audio::eng | media::image::eng | media::big-image::eng | media::video::eng |
+        |         | c1        | na   | la-d  | la-e       | la-d.mp3          | la-d.jpg          | la-d.jpg              | la-d.mkv          |
+        |         | c1        | nb   | lb-d  | lb-e       | lb-d.mp3          | lb-d.jpg          | lb-d.jpg              | lb-d.mkv          |
         """
         cols = {
             CHOICES: {
                 DEFAULT_LANG: (
                     "media::image",
+                    "media::big-image",
                     "media::video",
                     "media::audio",
                 )
@@ -1419,17 +1459,21 @@ class TestTranslationsChoices(PyxformTestCase):
                 self.xp.choice_itext_label("eng", "na", "la-e"),
                 self.xp.choice_itext_form("eng", "na", "audio", "la-d.mp3"),
                 self.xp.choice_itext_form("eng", "na", "image", "la-d.jpg"),
+                self.xp.choice_itext_form("eng", "na", "big-image", "la-d.jpg"),
                 self.xp.choice_itext_form("eng", "na", "video", "la-d.mkv"),
                 self.xp.choice_no_itext_form(DEFAULT_LANG, "na", "audio", "la-d.mp3"),
                 self.xp.choice_no_itext_form(DEFAULT_LANG, "na", "image", "la-d.jpg"),
+                self.xp.choice_no_itext_form(DEFAULT_LANG, "na", "big-image", "la-d.jpg"),
                 self.xp.choice_no_itext_form(DEFAULT_LANG, "na", "video", "la-d.mkv"),
                 self.xp.choice_itext_label(DEFAULT_LANG, "nb", "lb-d"),
                 self.xp.choice_itext_label("eng", "nb", "lb-e"),
                 self.xp.choice_itext_form("eng", "nb", "audio", "lb-d.mp3"),
                 self.xp.choice_itext_form("eng", "nb", "image", "lb-d.jpg"),
+                self.xp.choice_itext_form("eng", "nb", "big-image", "lb-d.jpg"),
                 self.xp.choice_itext_form("eng", "nb", "video", "lb-d.mkv"),
                 self.xp.choice_no_itext_form(DEFAULT_LANG, "nb", "audio", "lb-d.mp3"),
                 self.xp.choice_no_itext_form(DEFAULT_LANG, "nb", "image", "lb-d.jpg"),
+                self.xp.choice_no_itext_form(DEFAULT_LANG, "nb", "big-image", "lb-d.jpg"),
                 self.xp.choice_no_itext_form(DEFAULT_LANG, "nb", "video", "lb-d.mkv"),
                 self.xp.language_is_default(DEFAULT_LANG),
                 self.xp.language_is_not_default("eng"),
@@ -1446,9 +1490,9 @@ class TestTranslationsChoices(PyxformTestCase):
         |         | type          | name  | label      |
         |         | select_one c1 | q1    | Question 1 |
         | choices |           |      |                 |
-        |         | list name | name | label | label::eng | media::audio::eng | media::image::eng | media::video::eng |
-        |         | c1        | na   | la-d  | la-e       | la-d.mp3          | la-d.jpg          | la-d.mkv          |
-        |         | c1        | nb   | lb-d  | lb-e       | lb-d.mp3          | lb-d.jpg          | lb-d.mkv          |
+        |         | list name | name | label | label::eng | media::audio::eng | media::image::eng | media::big-image::eng | media::video::eng |
+        |         | c1        | na   | la-d  | la-e       | la-d.mp3          | la-d.jpg          | la-d.jpg              | la-d.mkv          |
+        |         | c1        | nb   | lb-d  | lb-e       | lb-d.mp3          | lb-d.jpg          | lb-d.jpg              | lb-d.mkv          |
         """
         # cols = {
         #     CHOICES: {
@@ -1474,10 +1518,12 @@ class TestTranslationsChoices(PyxformTestCase):
                 self.xp.choice_itext_label("eng", "na", "la-e"),
                 self.xp.choice_itext_form("eng", "na", "audio", "la-d.mp3"),
                 self.xp.choice_itext_form("eng", "na", "image", "la-d.jpg"),
+                self.xp.choice_itext_form("eng", "na", "big-image", "la-d.jpg"),
                 self.xp.choice_itext_form("eng", "na", "video", "la-d.mkv"),
                 self.xp.choice_itext_label("eng", "nb", "lb-e"),
                 self.xp.choice_itext_form("eng", "nb", "audio", "lb-d.mp3"),
                 self.xp.choice_itext_form("eng", "nb", "image", "lb-d.jpg"),
+                self.xp.choice_itext_form("eng", "nb", "big-image", "lb-d.jpg"),
                 self.xp.choice_itext_form("eng", "nb", "video", "lb-d.mkv"),
                 self.xp.language_is_default("eng"),
                 self.xp.language_no_itext(DEFAULT_LANG),

--- a/tests/test_xlsform_spec.py
+++ b/tests/test_xlsform_spec.py
@@ -21,6 +21,7 @@ class TestWarnings(PyxformTestCase):
         |          | select_multiple yes_no | select_multiple_test    | select multiple test      |         | minimal            |              |       |       |
         |          | end group              | adsaf                   |                           |         |                    |              |       |       |
         |          | begin group            | labeled_select_group    | labeled select group test |         | field-list         |              |       |       |
+        |          | text                   | inside                  | Inside                    |         |
         |          | end group              |                         |                           |         |                    |              |       |       |
         |          | begin group            | name                    |                           |         | table-list         |              |       |       |
         |          | select_one yes_no      | table_list_question     | table list question       | hint    |                    |              |       |       |
@@ -67,8 +68,8 @@ class TestWarnings(PyxformTestCase):
             "On the choices sheet there is a option with no label. [list_name : animals]",
             "[row : 9] Repeat has no label: {'name': 'repeat_test', 'type': 'begin repeat'}",
             "[row : 10] Group has no label: {'name': 'group_test', 'type': 'begin group'}",
-            "[row : 16] Group has no label: {'name': 'name', 'type': 'begin group'}",
-            "[row : 27] Use the max-pixels parameter to speed up submission "
+            "[row : 17] Group has no label: {'name': 'name', 'type': 'begin group'}",
+            "[row : 28] Use the max-pixels parameter to speed up submission "
             + "sending and save storage space. Learn more: https://xlsform.org/#image",
         ]
         self.assertListEqual(expected, warnings)


### PR DESCRIPTION
Closes #
- Fixed pyxform cannot installed using pip / requirements file in Form Designer because of invalid version number according to https://peps.python.org/pep-0440/
- Merging latest upstream release of pyxform

#### Why is this the best possible solution? Were any other approaches considered?

#### What are the regression risks?
No. All tests are passed.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments