### PR TITLE
OC-21710 Fixed bug when calculate items in multiple groups, the items is not in the end of form

### DIFF
--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -431,13 +431,15 @@ def extract_calculate_elements(json_node):
         if "children" in json_node and isinstance(json_node["children"], list):
             calculate_elements.extend(extract_calculate_elements(json_node["children"]))
     elif isinstance(json_node, list):
-        for element in json_node:
-            if element.get("type") == "calculate" and element.get("bind", {}).get(
-                "calculate"
+        # Iterating over copy of json_node list because we do operation (remove) on json_node list
+        for element in json_node[:]:
+            if element.get("type") == "calculate" and (
+                element.get("bind", {}).get("calculate") is not None
+                or element.get("default") is not None
             ):
                 calculate_elements.append(element)
                 json_node.remove(element)
-            if (
+            elif (
                 isinstance(element, dict)
                 and element.get("children")
                 and isinstance(element["children"], list)

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -863,21 +863,53 @@ class AnnotateLabelTest(PyxformTestCase):
         )
 
     def test_annotated_label__calculation_type_in_group(self):
-        """Test annotated label for calculation type item in group should be extracted to outside group and appended in the end of form"""
+        """Test annotated label for calculation type item in group should be extracted out of group and appended in the end of form"""
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |              |                |                |               |          |          |
-            |        | type         | name           | label          | calculation   | required | readonly |
-            |        | begin group  | group_1        |                |               |          |          |
-            |        | calculate    | calculate_type |                | 2+3           |          |          |
-            |        | date         | dob            | Date of birth: |               | yes      |          |
-            |        | date         | date_visit     | Date of visit: |               | yes      |          |
-            |        | end group    |                |                |               |          |          |
+            | survey |              |                  |                |               |          |          |
+            |        | type         | name             | label          | calculation   | required | default  |
+            |        | begin group  | group_1          |                |               |          |          |
+            |        | calculate    | calculate_type_1 |                | 2+3           |          |          |
+            |        | date         | dob              | Date of birth: |               | yes      |          |
+            |        | date         | date_visit       | Date of visit: |               | yes      |          |
+            |        | calculate    | calculate_type_2 |                |               |          | 1+1      |
+            |        | end group    |                  |                |               |          |          |
             """,
             xml__contains=[
-                '<input ref="/data/calculate_type">',
+                '<input ref="/data/calculate_type_1">',
+                '<input ref="/data/calculate_type_2">',
                 'style="color: black"&gt; [Type: calculate]&lt;/span&gt;&lt;span style="color: maroon"&gt; [Calculation: 2+3]&lt;/span&gt;</label>',
+                'style="color: black"&gt; [Type: calculate]&lt;/span&gt;&lt;span style="color: deepskyblue"&gt; [Default: 1+1]&lt;/span&gt;</label>',
+            ],
+            annotate=["all"],
+        )
+
+    def test_annotated_label__calculation_type_in_multiple_group(self):
+        """Test annotated label for calculation type item in multiple group should be extracted out of group and appended in the end of form"""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |              |                         |                |               |          |          |
+            |        | type         | name                    | label          | calculation   | required | default  |
+            |        | calculate    | calculate_type_no_group |                | 1+2           |          |          |
+            |        | begin group  | group_1                 |                |               |          |          |
+            |        | calculate    | calculate_type_group_1  |                | 2+3           |          |          |
+            |        | date         | dob                     | Date of birth: |               | yes      |          |
+            |        | date         | date_visit              | Date of visit: |               | yes      |          |
+            |        | end group    |                         |                |               |          |          |
+            |        | begin group  | group_2                 |                |               |          |          |
+            |        | calculate    | calculate_type_group_2  |                |               |          | 1+1      |
+            |        | integer      | order_no                | Order no:      |               | yes      |          |
+            |        | end group    |                         |                |               |          |          |
+            """,
+            xml__contains=[
+                '<input ref="/data/calculate_type_no_group">',
+                '<input ref="/data/calculate_type_group_1">',
+                '<input ref="/data/calculate_type_group_2">',
+                'style="color: black"&gt; [Type: calculate]&lt;/span&gt;&lt;span style="color: maroon"&gt; [Calculation: 1+2]&lt;/span&gt;</label>',
+                'style="color: black"&gt; [Type: calculate]&lt;/span&gt;&lt;span style="color: maroon"&gt; [Calculation: 2+3]&lt;/span&gt;</label>',
+                'style="color: black"&gt; [Type: calculate]&lt;/span&gt;&lt;span style="color: deepskyblue"&gt; [Default: 1+1]&lt;/span&gt;</label>',
             ],
             annotate=["all"],
         )


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?
Simple yet works.
#### What are the regression risks?
None.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
None.
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments