### PR TITLE
OC-21237 Remove autocomplete from appearance

### DIFF
--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -212,6 +212,18 @@ class MultipleChoiceQuestion(Question):
             control_dict[key] = survey.insert_xpaths(value, self)
         control_dict["ref"] = self.get_xpath()
 
+        # Annotated form:
+        # Remove the ‘autocomplete’ appearance from the select element
+        # because it causes the options to disappear
+        if len(survey.annotated_fields) > 0:
+            if (
+                isinstance(control_dict.get("appearance"), str)
+                and "autocomplete" in control_dict.get("appearance").split()
+            ):
+                control_dict["appearance"] = re.sub(
+                    "autocomplete", "", control_dict.get("appearance")
+                ).strip()
+
         result = node(**control_dict)
         for element in self.xml_label_and_hint():
             result.appendChild(element)

--- a/tests/test_annotate_label.py
+++ b/tests/test_annotate_label.py
@@ -206,6 +206,23 @@ class AnnotateLabelTest(PyxformTestCase):
             annotate=["all"],
         )
 
+    def test_annotate_label__no_autocomplete_appearance_for_select(self):
+        """Test annotated label for select one item."""
+        """Remove autocomplete appearance."""
+        self.assertPyxformXform(
+            md="""
+            | survey   |                     |      |       |                 |
+            |          | type                | name | label | appearance      |
+            |          | select_one choices1 | a    | A     | w2 autocomplete |
+            | choices  |                     |      |       |                 |
+            |          | list_name           | name | label |                 |
+            |          | choices1            | 1    | One   |                 |
+            |          | choices1            | 2    | Two   |                 |
+            """,
+            xml__contains=[r'<select1 appearance="w2"'],
+            annotate=["all"],
+        )
+
     def test_annotated_label__for_image(self):
         """Test annotated label for image."""
         self.assertPyxformXform(


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?

#### What are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments