### PR TITLE
OC-20813 Custom annotation labels must start with a letter or digit

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -683,6 +683,11 @@ class SurveyElement(dict):
                                     ):
                                         msg = "Custom annotation labels can only include letters, digits, underscores, and hyphens."
                                         raise PyXFormError(msg)
+                                    if not bool(
+                                        re.match(r"^[A-Za-z0-9]$", attr_label[0])
+                                    ):
+                                        msg = "Custom annotation labels must start with a letter or digit."
+                                        raise PyXFormError(msg)
                                     # Change _ with space in custom annotation label
                                     if "_" in attr_label:
                                         attr_label = attr_label.replace("_", " ").strip()


### PR DESCRIPTION
Closes #

#### Why is this the best possible solution? Were any other approaches considered?

#### What are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x]  run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments